### PR TITLE
Allow for preview mode in Strapi

### DIFF
--- a/backend/config/admin.ts
+++ b/backend/config/admin.ts
@@ -38,7 +38,6 @@ const getPreviewPathname = (uid, { locale, document }): string => {
 
 export default ({ env }: { env: (key: string, defaultValue?: any) => any }) => {
   const clientUrl = env("CLIENT_URL"); // Frontend application URL
-  const previewSecret = env("PREVIEW_SECRET"); // Secret key for preview authentication
 
   return {
     auth: {

--- a/backend/config/admin.ts
+++ b/backend/config/admin.ts
@@ -1,17 +1,80 @@
-export default ({ env }) => ({
-  auth: {
-    secret: env('ADMIN_JWT_SECRET'),
-  },
-  apiToken: {
-    salt: env('API_TOKEN_SALT'),
-  },
-  transfer: {
-    token: {
-      salt: env('TRANSFER_TOKEN_SALT'),
+interface AuthConfig {
+  secret: string;
+}
+
+interface ApiTokenConfig {
+  salt: string;
+}
+
+interface TransferTokenConfig {
+  salt: string;
+}
+
+interface TransferConfig {
+  token: TransferTokenConfig;
+}
+
+interface FlagsConfig {
+  nps: boolean;
+  promoteEE: boolean;
+}
+
+interface AdminConfig {
+  auth: AuthConfig;
+  apiToken: ApiTokenConfig;
+  transfer: TransferConfig;
+  flags: FlagsConfig;
+  preview: any;
+}
+
+const getPreviewPathname = (uid, { locale, document }): string => {
+  console.log('getPreviewPathname', uid, locale, document);
+  const { slug } = document;
+  switch (uid) {
+    case "api::post.post":
+      return `/blog/${slug}`;
+  }
+}
+
+export default ({ env }: { env: (key: string, defaultValue?: any) => any }) => {
+  const clientUrl = env("CLIENT_URL"); // Frontend application URL
+  const previewSecret = env("PREVIEW_SECRET"); // Secret key for preview authentication
+
+  return {
+    auth: {
+      secret: env('ADMIN_JWT_SECRET'),
     },
-  },
-  flags: {
-    nps: env.bool('FLAG_NPS', true),
-    promoteEE: env.bool('FLAG_PROMOTE_EE', true),
-  },
-});
+    apiToken: {
+      salt: env('API_TOKEN_SALT'),
+    },
+    transfer: {
+      token: {
+        salt: env('TRANSFER_TOKEN_SALT'),
+      },
+    },
+    flags: {
+      nps: env('FLAG_NPS', 'true') === 'true',
+      promoteEE: env('FLAG_PROMOTE_EE', 'true') === 'true',
+    },
+    preview: {
+      enabled: true,
+      config: {
+        allowedOrigins: env('CLIENT_URL'),
+        async handler(uid, { documentId, locale, status }) {
+          const document = await strapi.documents(uid).findOne({ documentId });
+          const pathname = getPreviewPathname(uid, { locale, document });
+          if (!pathname) {
+            return null;
+          }
+          const urlSearchParams = new URLSearchParams({
+            status: "draft",
+          });
+          const previewUrl = new URL(`${clientUrl}${pathname}`);
+          previewUrl.search = urlSearchParams.toString();
+          console.log('previewUrl', previewUrl);
+          return previewUrl;
+        },
+      },
+    },
+  } as AdminConfig;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,9 +18,12 @@ export async function fetchPosts() {
     }
 }
 
-export async function fetchPostBySlug(slug: string) {
+export async function fetchPostBySlug(slug: string, preview: boolean = false) {
     try {
-        const reqUrl = `${STRAPI_URL}/api/posts?filters[slug][$eq]=${slug}&populate=*`
+        let reqUrl = `${STRAPI_URL}/api/posts?filters[slug][$eq]=${slug}&populate=*`
+        if (preview) {
+            reqUrl += "&status=draft"
+        }
         console.debug("Fetching posts from:", reqUrl)
         const response = await fetch(reqUrl)
 

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -8,7 +8,9 @@ import StravaEmbed from "../../components/StravaEmbed.astro";
 
 const { slug } = Astro.params;
 
-const post = await fetchPostBySlug(slug!);
+// extract query params
+const previewMode = Astro.url.searchParams.get('status') == "draft";
+const post = await fetchPostBySlug(slug!, previewMode)
 const htmlContent = await marked(post.content);
 const image = getLargestImage(post);
 const imageUrl = getMediaUrl(image?.url);
@@ -32,8 +34,8 @@ const imageUrl = getMediaUrl(image?.url);
 
         <h1 class="text-4xl font-bold mb-4">{post.title}</h1>
         <h2 class="text-2xl font-bold mb-3">
-            Written by {post.createdBy.firstname}
-            {post.createdBy.lastname} on {
+            Written by {post.createdBy?.firstname}
+            {post.createdBy?.lastname} on {
                 new Date(post.publishedDate).toLocaleDateString()
             }
         </h2>


### PR DESCRIPTION
This PR is a first (and hopefully only) stab at enabling post previews in Strapi. 

Updates
---
- Modifies the strapi admin config to enable preview mode, and adds the necessary preview url generation logic.
- Modifies the astro client application to check for query params and request either draft mode or publish mode posts

On Deploy
---
ensure that preview-mode posts don't display on the home page
define CLIENT_URL in the strapi cloud portal

Possible Followups
---
It would be nice to have the preview display without having to click into "Show preview"