### PR TITLE
Document all make commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,13 @@ Hill People is a blog platform with an Astro frontend (https://hillpeople.net) a
 
 ### Quick Start (from repo root)
 ```bash
-make dev           # Frontend against local Strapi (localhost:1337)
-make dev-prod      # Frontend against production Strapi
-make sync-data     # Pull production data to local Strapi
+make dev                   # Frontend against local Strapi (localhost:1337)
+make dev-prod              # Frontend against production Strapi
+make backend               # Run local Strapi backend
+make sync-data             # Pull production data to local Strapi
+make migrate-ckeditor      # Migrate markdown content to CKEditor HTML (requires STRAPI_TOKEN)
+make migrate-ckeditor-dry  # Preview migration without writing (requires STRAPI_TOKEN)
+make upgrade-strapi        # Upgrade Strapi to latest version
 ```
 
 ### Frontend (from `frontend/` directory)


### PR DESCRIPTION
## Summary
- Added missing make commands to CLAUDE.md: `backend`, `migrate-ckeditor`, `migrate-ckeditor-dry`, `upgrade-strapi`

## Test plan
- [x] Verify all commands match Makefile

🤖 Generated with [Claude Code](https://claude.com/claude-code)