### PR TITLE
Newsletter: Add Subscriber collection type

### DIFF
--- a/backend/src/api/subscriber/content-types/subscriber/schema.json
+++ b/backend/src/api/subscriber/content-types/subscriber/schema.json
@@ -1,0 +1,39 @@
+{
+  "kind": "collectionType",
+  "collectionName": "subscribers",
+  "info": {
+    "singularName": "subscriber",
+    "pluralName": "subscribers",
+    "displayName": "Subscriber"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "email": {
+      "type": "email",
+      "required": true,
+      "unique": true
+    },
+    "confirmed": {
+      "type": "boolean",
+      "default": false
+    },
+    "confirmationToken": {
+      "type": "string",
+      "private": true
+    },
+    "tokenExpiry": {
+      "type": "datetime",
+      "private": true
+    },
+    "unsubscribeToken": {
+      "type": "string",
+      "private": true
+    },
+    "subscribedAt": {
+      "type": "datetime"
+    }
+  }
+}

--- a/backend/src/api/subscriber/controllers/subscriber.ts
+++ b/backend/src/api/subscriber/controllers/subscriber.ts
@@ -1,0 +1,7 @@
+/**
+ * subscriber controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::subscriber.subscriber');

--- a/backend/src/api/subscriber/routes/subscriber.ts
+++ b/backend/src/api/subscriber/routes/subscriber.ts
@@ -1,0 +1,7 @@
+/**
+ * subscriber router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::subscriber.subscriber');

--- a/backend/src/api/subscriber/services/subscriber.ts
+++ b/backend/src/api/subscriber/services/subscriber.ts
@@ -1,0 +1,7 @@
+/**
+ * subscriber service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::subscriber.subscriber');

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -507,6 +507,41 @@ export interface ApiPostPost extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiSubscriberSubscriber extends Struct.CollectionTypeSchema {
+  collectionName: 'subscribers';
+  info: {
+    displayName: 'Subscriber';
+    pluralName: 'subscribers';
+    singularName: 'subscriber';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;
+    confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    email: Schema.Attribute.Email &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::subscriber.subscriber'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    subscribedAt: Schema.Attribute.DateTime;
+    tokenExpiry: Schema.Attribute.DateTime & Schema.Attribute.Private;
+    unsubscribeToken: Schema.Attribute.String & Schema.Attribute.Private;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface PluginContentReleasesRelease
   extends Struct.CollectionTypeSchema {
   collectionName: 'strapi_releases';
@@ -1019,6 +1054,7 @@ declare module '@strapi/strapi' {
       'admin::user': AdminUser;
       'api::about.about': ApiAboutAbout;
       'api::post.post': ApiPostPost;
+      'api::subscriber.subscriber': ApiSubscriberSubscriber;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;


### PR DESCRIPTION
Closes #50

## Summary
- Creates `Subscriber` collection type for storing newsletter subscriptions
- Fields: email (unique), confirmed, confirmationToken, tokenExpiry, unsubscribeToken, subscribedAt
- Private fields (`confirmationToken`, `tokenExpiry`, `unsubscribeToken`) are not exposed in API responses

## Post-merge setup required

After merging and deploying, create these API tokens in Strapi admin (Settings > API Tokens):

### 1. Frontend Subscribe Token
- Name: `Frontend Subscribe`
- Type: Custom
- Permissions: `Subscriber` → `create` ONLY
- Used by: Frontend form submission

### 2. Newsletter Worker Token
- Name: `Newsletter Worker`
- Type: Custom
- Permissions:
  - `Subscriber` → `find`
  - `Post` → `find`, `update`
- Used by: Cloudflare Worker (secret)

### 3. Audit existing tokens
- Ensure no existing tokens have `Subscriber` read access

## Test plan
- [x] `make backend` starts without errors
- [x] "Subscriber" appears in Content-Type Builder
- [x] Can create subscriber via admin panel
- [x] API tokens can be configured with scoped permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)