### PR TITLE
Newsletter: Add Privacy Policy single type and page

### DIFF
--- a/backend/src/api/privacy-policy/content-types/privacy-policy/schema.json
+++ b/backend/src/api/privacy-policy/content-types/privacy-policy/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "singleType",
+  "collectionName": "privacy_policies",
+  "info": {
+    "singularName": "privacy-policy",
+    "pluralName": "privacy-policies",
+    "displayName": "Privacy Policy"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "default": "Privacy Policy"
+    },
+    "content": {
+      "type": "richtext"
+    },
+    "richContent": {
+      "type": "customField",
+      "options": {
+        "preset": "defaultHtml"
+      },
+      "customField": "plugin::ckeditor5.CKEditor"
+    },
+    "lastUpdated": {
+      "type": "datetime"
+    }
+  }
+}

--- a/backend/src/api/privacy-policy/controllers/privacy-policy.ts
+++ b/backend/src/api/privacy-policy/controllers/privacy-policy.ts
@@ -1,0 +1,7 @@
+/**
+ * privacy-policy controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::privacy-policy.privacy-policy');

--- a/backend/src/api/privacy-policy/routes/privacy-policy.ts
+++ b/backend/src/api/privacy-policy/routes/privacy-policy.ts
@@ -1,0 +1,7 @@
+/**
+ * privacy-policy router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::privacy-policy.privacy-policy');

--- a/backend/src/api/privacy-policy/services/privacy-policy.ts
+++ b/backend/src/api/privacy-policy/services/privacy-policy.ts
@@ -1,0 +1,7 @@
+/**
+ * privacy-policy service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::privacy-policy.privacy-policy');

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -507,6 +507,45 @@ export interface ApiPostPost extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiPrivacyPolicyPrivacyPolicy extends Struct.SingleTypeSchema {
+  collectionName: 'privacy_policies';
+  info: {
+    displayName: 'Privacy Policy';
+    pluralName: 'privacy-policies';
+    singularName: 'privacy-policy';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    content: Schema.Attribute.RichText;
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    lastUpdated: Schema.Attribute.DateTime;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::privacy-policy.privacy-policy'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    richContent: Schema.Attribute.RichText &
+      Schema.Attribute.CustomField<
+        'plugin::ckeditor5.CKEditor',
+        {
+          preset: 'defaultHtml';
+        }
+      >;
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'Privacy Policy'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiSubscriberSubscriber extends Struct.CollectionTypeSchema {
   collectionName: 'subscribers';
   info: {
@@ -1054,6 +1093,7 @@ declare module '@strapi/strapi' {
       'admin::user': AdminUser;
       'api::about.about': ApiAboutAbout;
       'api::post.post': ApiPostPost;
+      'api::privacy-policy.privacy-policy': ApiPrivacyPolicyPrivacyPolicy;
       'api::subscriber.subscriber': ApiSubscriberSubscriber;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -1,0 +1,42 @@
+---
+import Layout from "../layouts/Layout.astro";
+import Prose from "../components/Prose.astro";
+import { marked } from "marked";
+import { fetchSingleType } from "../lib/api";
+import { transformContentUrls } from "../lib/imageUrl";
+
+const privacy = await fetchSingleType("privacy-policy");
+
+// Use CKEditor richContent if available, fallback to markdown content
+const useRichContent = !!privacy?.richContent;
+const rawHtml = useRichContent
+  ? privacy.richContent
+  : privacy?.content
+    ? await marked(privacy.content)
+    : "";
+// Transform relative /uploads/ URLs to absolute Strapi URLs
+const htmlContent = transformContentUrls(rawHtml);
+
+const title = privacy?.title || "Privacy Policy";
+const lastUpdated = privacy?.lastUpdated
+  ? new Date(privacy.lastUpdated).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+  : null;
+---
+
+<Layout pageTitle={title}>
+  <div class="max-w-3xl mx-auto px-4 py-10">
+    <h1 class="text-4xl font-bold mb-4">{title}</h1>
+    {lastUpdated && (
+      <p class="text-sm text-gray-500 mb-8">Last updated: {lastUpdated}</p>
+    )}
+    {htmlContent ? (
+      <Prose set:html={htmlContent} />
+    ) : (
+      <p class="text-gray-500">Privacy policy content coming soon.</p>
+    )}
+  </div>
+</Layout>


### PR DESCRIPTION
Closes #51

## Summary
- Creates `Privacy Policy` single type in Strapi with title, content, richContent, lastUpdated fields
- Adds `/privacy` frontend page that fetches and displays the policy

## Post-merge setup

1. Create Privacy Policy content in Strapi admin (Content Manager > Single Types > Privacy Policy)
2. Add honest privacy policy content (suggested text in issue #51)
3. Publish the content
4. Enable public `find` permission for Privacy Policy (Settings > Users & Permissions > Roles > Public)

## Test plan
- [x] `make backend` starts without errors
- [x] "Privacy Policy" appears in Single Types
- [x] `/privacy` page renders (shows fallback if no content yet)
- [x] After adding content in Strapi, page displays it correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)