### PR TITLE
Switch from Cloudflare Email to Resend for newsletter

### DIFF
--- a/newsletter-worker/package-lock.json
+++ b/newsletter-worker/package-lock.json
@@ -7,34 +7,10 @@
     "": {
       "name": "hillpeople-newsletter",
       "version": "1.0.0",
-      "dependencies": {
-        "mimetext": "^3.0.0"
-      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250124.0",
         "typescript": "^5.5.0",
         "wrangler": "^4.61.1"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-      "integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.43.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1209,17 +1185,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1297,12 +1262,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1311,43 +1270,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimetext": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
-      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@babel/runtime-corejs3": "^7.26.0",
-        "js-base64": "^3.7.7",
-        "mime-types": "^2.1.35"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/muratgozel"
       }
     },
     "node_modules/miniflare": {

--- a/newsletter-worker/package.json
+++ b/newsletter-worker/package.json
@@ -7,9 +7,6 @@
     "deploy": "wrangler deploy",
     "types": "wrangler types"
   },
-  "dependencies": {
-    "mimetext": "^3.0.0"
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250124.0",
     "typescript": "^5.5.0",

--- a/newsletter-worker/wrangler.toml
+++ b/newsletter-worker/wrangler.toml
@@ -6,9 +6,6 @@ compatibility_flags = ["nodejs_compat"]
 [triggers]
 crons = ["0 9 * * *"]  # Daily at 9 AM UTC
 
-[[send_email]]
-name = "EMAIL"
-
 [vars]
 STRAPI_API_URL = "https://journal.hillpeople.net"
 FRONTEND_URL = "https://hillpeople.net"
@@ -17,3 +14,4 @@ WORKER_URL = "https://hillpeople-newsletter.evannoronha.workers.dev"
 
 # Secrets (set via `wrangler secret put`):
 # - STRAPI_NEWSLETTER_TOKEN: API token for reading subscribers and updating posts
+# - RESEND_API_KEY: API key from Resend (https://resend.com)


### PR DESCRIPTION
## Summary
- Replace `cloudflare:email` binding with Resend REST API for sending emails
- Remove `mimetext` dependency (no longer needed with Resend)
- Resend offers 3,000 free emails/month and can send to any email address

## Changes
- `newsletter-worker/src/index.ts`: New `sendEmail()` function using Resend API
- `newsletter-worker/wrangler.toml`: Removed `send_email` binding, added `RESEND_API_KEY` secret docs
- `newsletter-worker/package.json`: Removed `mimetext` dependency

## Setup required
1. Create account at https://resend.com
2. Add and verify `hillpeople.net` domain in Resend dashboard
3. Create API key in Resend dashboard
4. Set secret: `cd newsletter-worker && wrangler secret put RESEND_API_KEY`
5. Deploy: `cd newsletter-worker && npm run deploy`

## Test plan
- [x] Resend domain verified for hillpeople.net
- [x] RESEND_API_KEY secret set in worker
- [x] Worker deployed
- [x] Subscribe with any email address
- [x] Confirmation email received
- [x] Click confirm link, subscriber marked confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)