### PR TITLE
Fix Strapi 5 $in filter syntax for post IDs

### DIFF
--- a/newsletter-worker/src/index.ts
+++ b/newsletter-worker/src/index.ts
@@ -282,15 +282,15 @@ async function sendNewsletter(env: Env, toOverride?: string, postIdsOverride?: n
 
   let posts: Post[];
   if (postIdsOverride && postIdsOverride.length > 0) {
-    // Fetch specific posts by ID
-    const postFilters = postIdsOverride.map(id => `filters[id][$in]=${id}`).join('&');
-    const response = await fetch(
-      `${env.STRAPI_API_URL}/api/posts?${postFilters}&filters[publishedAt][$notNull]=true`,
-      {
-        headers: { Authorization: `Bearer ${env.STRAPI_NEWSLETTER_TOKEN}` },
-      }
-    );
+    // Fetch specific posts by ID (Strapi 5 requires indexed array syntax for $in)
+    const postFilters = postIdsOverride.map((id, i) => `filters[id][$in][${i}]=${id}`).join('&');
+    const url = `${env.STRAPI_API_URL}/api/posts?${postFilters}&filters[publishedAt][$notNull]=true`;
+    console.log(`Fetching posts with URL: ${url}`);
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${env.STRAPI_NEWSLETTER_TOKEN}` },
+    });
     const data = await response.json() as StrapiResponse<Post[]>;
+    console.log(`Strapi response: ${JSON.stringify(data)}`);
     posts = data.data || [];
   } else {
     // Fetch posts that haven't been sent and weren't recently updated


### PR DESCRIPTION
## Summary
Fix the `$in` filter syntax for fetching posts by ID. Strapi 5 requires indexed array syntax:

**Before (broken):** `filters[id][$in]=1&filters[id][$in]=2`
**After (working):** `filters[id][$in][0]=1&filters[id][$in][1]=2`

Also added logging to help debug post fetching issues.

## Test plan
- [x] Deploy worker: `make newsletter-deploy`
- [x] Test: `make newsletter-send-force TO=your@email.com POSTS=1`
- [ ] Verify email received with post content

🤖 Generated with [Claude Code](https://claude.com/claude-code)