### PR TITLE
Add godmode endpoint for newsletter testing

### DIFF
--- a/newsletter-worker/setup-godmode.sh
+++ b/newsletter-worker/setup-godmode.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+echo "=== Setting up GODMODE_TOKEN for newsletter worker ==="
+echo
+
+# Generate token
+TOKEN=$(openssl rand -hex 32)
+echo "Generated token: $TOKEN"
+echo
+
+# Set as Cloudflare secret
+echo "Setting GODMODE_TOKEN as Cloudflare secret..."
+echo "$TOKEN" | npx wrangler secret put GODMODE_TOKEN
+echo
+
+# Deploy the worker
+echo "Deploying worker..."
+npx wrangler deploy
+echo
+
+# Save token locally
+ENV_FILE="$HOME/.hillpeople-newsletter"
+echo "GODMODE_TOKEN=$TOKEN" > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+echo "Token saved to $ENV_FILE"
+echo
+
+echo "=== Setup complete! ==="
+echo
+echo "To use godmode, either:"
+echo "  1. Source the env file:  source $ENV_FILE"
+echo "  2. Or export directly:   export GODMODE_TOKEN=$TOKEN"
+echo
+echo "Then run:"
+echo "  make newsletter-godmode-send POSTS=1,2,3 TO=test@example.com"

--- a/newsletter-worker/wrangler.toml
+++ b/newsletter-worker/wrangler.toml
@@ -15,3 +15,4 @@ WORKER_URL = "https://hillpeople-newsletter.evannoronha.workers.dev"
 # Secrets (set via `wrangler secret put`):
 # - STRAPI_NEWSLETTER_TOKEN: API token for reading subscribers and updating posts
 # - RESEND_API_KEY: API key from Resend (https://resend.com)
+# - GODMODE_TOKEN: Auth token for /godmode endpoint (bypasses all filters)


### PR DESCRIPTION
## Summary
- Add `/godmode` endpoint that bypasses eligibility filters (`newsletterSent`, `updatedAt`)
- Accept post slugs instead of numeric IDs for easier use (Strapi admin UI IDs don't match API IDs)
- Require `GODMODE_TOKEN` auth header for security
- Unify normal and godmode codepaths into single `sendNewsletter` function with `NewsletterOptions` interface
- Add `setup-godmode.sh` script for initial token setup
- Add `make newsletter-godmode-send` command

## Usage

```bash
# Initial setup (generates token, sets secret, deploys)
cd newsletter-worker && ./setup-godmode.sh

# Send specific posts to all subscribers
GODMODE_TOKEN=xxx make newsletter-godmode-send SLUGS=west-seattle-long-run

# Send to specific email only
GODMODE_TOKEN=xxx make newsletter-godmode-send SLUGS=west-seattle-long-run TO=test@example.com
```

## Test plan
- [x] Tested godmode endpoint with valid slugs
- [x] Verified emails are sent correctly
- [x] Confirmed posts are NOT marked as sent in godmode
- [x] Verified auth token is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)