### PR TITLE
Add SEO component with meta tags and social sharing

### DIFF
--- a/frontend/src/components/PostCard.astro
+++ b/frontend/src/components/PostCard.astro
@@ -3,7 +3,8 @@ import { getLargestImage, getMediaUrl } from "../lib/imageUrl";
 
 const { post } = Astro.props;
 
-const { title, slug, publishedDate } = post;
+const { title, slug, publishedDate, seo } = post;
+const excerpt = seo?.excerpt;
 const largestImage = getLargestImage(post);
 const imageUrl = largestImage ? getMediaUrl(largestImage.url) : null;
 const postUrl = `/blog/${slug}`;
@@ -34,7 +35,12 @@ const postUrl = `/blog/${slug}`;
         <h3 class="text-xl font-semibold leading-tight">
             {title}
         </h3>
-        <p class="text-sm mt-1">
+        {excerpt && (
+            <p class="text-sm mt-2 line-clamp-2">
+                {excerpt}
+            </p>
+        )}
+        <p class="text-sm mt-2 opacity-70">
             {
                 new Date(publishedDate).toLocaleDateString(undefined, {
                     year: "numeric",

--- a/frontend/src/components/SEO.astro
+++ b/frontend/src/components/SEO.astro
@@ -1,0 +1,44 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  canonicalUrl?: string;
+  ogImage?: string;
+  ogType?: 'website' | 'article';
+  publishedTime?: string;
+  authorName?: string;
+  noindex?: boolean;
+  siteName?: string;
+}
+
+const {
+  title,
+  description,
+  canonicalUrl,
+  ogImage,
+  ogType = 'website',
+  publishedTime,
+  authorName,
+  noindex = false,
+  siteName = 'Hill People',
+} = Astro.props;
+
+const fullTitle = title === 'Home' ? siteName : `${title} - ${siteName}`;
+const url = canonicalUrl || Astro.url.href;
+---
+
+<!-- Primary Meta Tags -->
+<title>{fullTitle}</title>
+<meta name="description" content={description} />
+{noindex && <meta name="robots" content="noindex, nofollow" />}
+<link rel="canonical" href={url} />
+
+<!-- Open Graph -->
+<meta property="og:type" content={ogType} />
+<meta property="og:url" content={url} />
+<meta property="og:title" content={fullTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:site_name" content={siteName} />
+{ogImage && <meta property="og:image" content={ogImage} />}
+{publishedTime && <meta property="article:published_time" content={publishedTime} />}
+{authorName && <meta property="article:author" content={authorName} />}

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -4,13 +4,30 @@ import Favicons from "../components/Favicons.astro";
 import Header from "../components/Header.astro";
 import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import NewsletterSignup from "../components/NewsletterSignup.astro";
+import SEO from "../components/SEO.astro";
 import { fetchSingleType } from "../lib/api";
 
 interface Props {
 	pageTitle: string;
+	description?: string;
+	ogImage?: string;
+	ogType?: 'website' | 'article';
+	publishedTime?: string;
+	authorName?: string;
+	noindex?: boolean;
+	siteName?: string;
 }
 
-const { pageTitle } = Astro.props;
+const {
+	pageTitle,
+	description = '',
+	ogImage,
+	ogType = 'website',
+	publishedTime,
+	authorName,
+	noindex = false,
+	siteName,
+} = Astro.props;
 
 // Fetch home page content for newsletter FAB (shown on all pages)
 const homePage = await fetchSingleType("home-page");
@@ -21,6 +38,16 @@ const homePage = await fetchSingleType("home-page");
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
+		<SEO
+			title={pageTitle}
+			description={description}
+			ogImage={ogImage}
+			ogType={ogType}
+			publishedTime={publishedTime}
+			authorName={authorName}
+			noindex={noindex}
+			siteName={siteName}
+		/>
 		<GoogleAnalytics />
 		<Favicons />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -30,7 +57,6 @@ const homePage = await fetchSingleType("home-page");
 			rel="stylesheet"
 		/>
 		<meta name="generator" content={Astro.generator} />
-		<title>Hill People - {pageTitle}</title>
 	</head>
 	<body>
 		<Header />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -96,3 +96,7 @@ export async function fetchSingleType(pageName: string) {
         return null
     }
 }
+
+export async function fetchSiteSettings() {
+    return fetchSingleType("site-settings")
+}

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -2,10 +2,13 @@
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
 import { marked } from "marked";
-import { fetchSingleType } from "../lib/api";
-import { getLargestImage, getMediaUrl, transformContentUrls } from "../lib/imageUrl";
+import { fetchSingleType, fetchSiteSettings } from "../lib/api";
+import { getMediaUrl, transformContentUrls } from "../lib/imageUrl";
 
-const about = await fetchSingleType("about");
+const [about, siteSettings] = await Promise.all([
+    fetchSingleType("about"),
+    fetchSiteSettings(),
+]);
 
 // Use CKEditor richContent if available, fallback to markdown content
 const useRichContent = !!about.richContent;
@@ -15,9 +18,18 @@ const htmlContent = transformContentUrls(rawHtml);
 
 const image = about.images[0];
 const imageUrl = getMediaUrl(image.url);
+
+// SEO data
+const siteName = siteSettings?.siteName || "Hill People";
+const description = `Learn more about ${siteName}`;
 ---
 
-<Layout pageTitle={about.title}>
+<Layout
+    pageTitle={about.title}
+    description={description}
+    ogImage={imageUrl}
+    siteName={siteName}
+>
     <div class="max-w-3xl mx-auto px-4 py-10">
         <div class="aspect-square overflow-hidden mb-8 rounded-xl">
             <img

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -2,7 +2,7 @@
 import { marked } from "marked";
 import Layout from "../../layouts/Layout.astro";
 import Prose from "../../components/Prose.astro";
-import { fetchPostBySlug } from "../../lib/api";
+import { fetchPostBySlug, fetchSiteSettings } from "../../lib/api";
 import { getMediaUrl, getLargestImage, transformContentUrls } from "../../lib/imageUrl";
 import StravaEmbed from "../../components/StravaEmbed.astro";
 
@@ -10,7 +10,10 @@ const { slug } = Astro.params;
 
 // extract query params
 const previewMode = Astro.url.searchParams.get("status") == "draft";
-const post = await fetchPostBySlug(slug!, previewMode);
+const [post, siteSettings] = await Promise.all([
+    fetchPostBySlug(slug!, previewMode),
+    fetchSiteSettings(),
+]);
 
 if (!post) {
     return Astro.rewrite("/404");
@@ -24,9 +27,23 @@ const htmlContent = transformContentUrls(rawHtml);
 
 const image = getLargestImage(post);
 const imageUrl = getMediaUrl(image?.url);
+
+// SEO data (fields are nested under post.seo component)
+const seoTitle = post.seo?.metaTitle || post.title;
+const seoDescription = post.seo?.metaDescription || post.seo?.excerpt || "";
+const authorName = post.authorName || `${post.createdBy?.firstname || ""} ${post.createdBy?.lastname || ""}`.trim();
+const siteName = siteSettings?.siteName || "Hill People";
 ---
 
-<Layout pageTitle={post.title}>
+<Layout
+    pageTitle={seoTitle}
+    description={seoDescription}
+    ogImage={imageUrl}
+    ogType="article"
+    publishedTime={post.publishedDate}
+    authorName={authorName}
+    siteName={siteName}
+>
     <article class="max-w-3xl mx-auto px-4 py-10">
         {
             imageUrl && (
@@ -42,8 +59,7 @@ const imageUrl = getMediaUrl(image?.url);
 
         <h1 class="text-4xl font-bold mb-4">{post.title}</h1>
         <h2 class="text-2xl font-bold mb-3 mt-12">
-            Written by {post.author_override ? post.author_override[0] : post.createdBy?.firstname}
-            {post.createdBy?.lastname} on {
+            Written by {authorName} on {
                 new Date(post.publishedDate).toLocaleDateString()
             }
         </h2>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -2,19 +2,31 @@
 import PostCard from "../components/PostCard.astro";
 import Layout from "../layouts/Layout.astro";
 import Hero from "../components/Hero.astro";
-import { fetchPostsPaginated, fetchSingleType } from "../lib/api";
+import { fetchPostsPaginated, fetchSingleType, fetchSiteSettings } from "../lib/api";
+import { getMediaUrl } from "../lib/imageUrl";
 
 const PAGE_SIZE = 6;
 
-const [{ posts, pagination }, homePage] = await Promise.all([
+const [{ posts, pagination }, homePage, siteSettings] = await Promise.all([
 	fetchPostsPaginated(1, PAGE_SIZE),
 	fetchSingleType("home-page"),
+	fetchSiteSettings(),
 ]);
 
 const hasMore = pagination.pageCount > 1;
+
+// SEO data
+const siteName = siteSettings?.siteName || "Hill People";
+const description = siteSettings?.siteDescription || "Stories from the hills";
+const ogImage = siteSettings?.defaultOgImage ? getMediaUrl(siteSettings.defaultOgImage.url) : undefined;
 ---
 
-<Layout pageTitle="Home">
+<Layout
+	pageTitle="Home"
+	description={description}
+	ogImage={ogImage}
+	siteName={siteName}
+>
 	{homePage && (
 		<Hero
 			title={homePage.heroTitle}

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -2,10 +2,13 @@
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
 import { marked } from "marked";
-import { fetchSingleType } from "../lib/api";
+import { fetchSingleType, fetchSiteSettings } from "../lib/api";
 import { transformContentUrls } from "../lib/imageUrl";
 
-const privacy = await fetchSingleType("privacy-policy");
+const [privacy, siteSettings] = await Promise.all([
+    fetchSingleType("privacy-policy"),
+    fetchSiteSettings(),
+]);
 
 // Use CKEditor richContent if available, fallback to markdown content
 const useRichContent = !!privacy?.richContent;
@@ -25,9 +28,18 @@ const lastUpdated = privacy?.lastUpdated
       day: 'numeric'
     })
   : null;
+
+// SEO data
+const siteName = siteSettings?.siteName || "Hill People";
+const description = `Privacy policy for ${siteName}`;
 ---
 
-<Layout pageTitle={title}>
+<Layout
+    pageTitle={title}
+    description={description}
+    siteName={siteName}
+    noindex={true}
+>
   <div class="max-w-3xl mx-auto px-4 py-10">
     <h1 class="text-4xl font-bold mb-4">{title}</h1>
     {lastUpdated && (


### PR DESCRIPTION
## Summary

Add SEO meta tags and Open Graph support to improve search rankings and social sharing.

## New Files

### `frontend/src/components/SEO.astro`
Centralized SEO component that generates:
- Page title with site name suffix
- Meta description
- Canonical URL
- Open Graph tags (type, url, title, description, site_name, image)
- Article metadata (published_time, author)
- Robots noindex directive (optional)

## Modified Files

### `frontend/src/layouts/Layout.astro`
- Import and render SEO component in `<head>`
- Accept SEO props (description, ogImage, ogType, publishedTime, authorName, noindex, siteName)
- Remove hardcoded `<title>` tag (now handled by SEO component)

### `frontend/src/lib/api.ts`
- Add `fetchSiteSettings()` function to fetch global SEO configuration

### `frontend/src/pages/index.astro`
- Fetch site-settings for homepage SEO data
- Pass description, ogImage, siteName to Layout

### `frontend/src/pages/blog/[slug].astro`
- Fetch site-settings alongside post data
- Extract SEO fields from `post.seo` component (metaTitle, metaDescription, excerpt)
- Pass article-specific SEO data (ogType=article, publishedTime, authorName)
- Fix author display to use `post.authorName` field with fallback to createdBy

### `frontend/src/pages/about.astro`
- Fetch site-settings for siteName
- Pass description and ogImage to Layout

### `frontend/src/pages/privacy.astro`
- Fetch site-settings for siteName
- Pass noindex=true to prevent search indexing

### `frontend/src/components/PostCard.astro`
- Display post excerpt from `post.seo.excerpt` on homepage cards
- Add line-clamp-2 for consistent excerpt length

## Dependencies

Requires PR #74 to be merged first for:
- `seo` component on posts (excerpt, metaTitle, metaDescription)
- `authorName` field on posts
- `site-settings` single type (siteName, siteDescription, defaultOgImage)

## Test Plan

1. Build: `cd frontend && npm run build`
2. Dev server: `make dev-prod`
3. View page source - verify meta tags on each page

Part 2 of 3 for #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)