### PR TITLE
Remove markdown fallback code from frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ npm run upgrade    # Upgrade Strapi to latest version
 
 ### Data Flow
 1. Frontend fetches posts from Strapi API (`/api/posts?populate=*`)
-2. Post content is stored as markdown in Strapi, converted to HTML using `marked` library
+2. Post content is stored as HTML in Strapi using CKEditor (`richContent` field)
 3. Images are served with responsive formats (xlarge, large, medium, small, xsmall)
 
 ### Frontend (`frontend/src/`)

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
-import { marked } from "marked";
 import { fetchSingleType, fetchSiteSettings } from "../lib/api";
 import { getMediaUrl, transformContentUrls } from "../lib/imageUrl";
 
@@ -10,11 +9,8 @@ const [about, siteSettings] = await Promise.all([
     fetchSiteSettings(),
 ]);
 
-// Use CKEditor richContent if available, fallback to markdown content
-const useRichContent = !!about.richContent;
-const rawHtml = useRichContent ? about.richContent : await marked(about.content);
 // Transform relative /uploads/ URLs to absolute Strapi URLs
-const htmlContent = transformContentUrls(rawHtml);
+const htmlContent = transformContentUrls(about.richContent);
 
 const image = about.images[0];
 const imageUrl = getMediaUrl(image.url);

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -1,5 +1,4 @@
 ---
-import { marked } from "marked";
 import Layout from "../../layouts/Layout.astro";
 import Prose from "../../components/Prose.astro";
 import { fetchPostBySlug, fetchSiteSettings } from "../../lib/api";
@@ -19,11 +18,8 @@ if (!post) {
     return Astro.rewrite("/404");
 }
 
-// Use CKEditor richContent if available, fallback to markdown content
-const useRichContent = !!post.richContent;
-const rawHtml = useRichContent ? post.richContent : await marked(post.content);
 // Transform relative /uploads/ URLs to absolute Strapi URLs
-const htmlContent = transformContentUrls(rawHtml);
+const htmlContent = transformContentUrls(post.richContent);
 
 const image = getLargestImage(post);
 const imageUrl = getMediaUrl(image?.url);

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
-import { marked } from "marked";
 import { fetchSingleType, fetchSiteSettings } from "../lib/api";
 import { transformContentUrls } from "../lib/imageUrl";
 
@@ -10,15 +9,8 @@ const [privacy, siteSettings] = await Promise.all([
     fetchSiteSettings(),
 ]);
 
-// Use CKEditor richContent if available, fallback to markdown content
-const useRichContent = !!privacy?.richContent;
-const rawHtml = useRichContent
-  ? privacy.richContent
-  : privacy?.content
-    ? await marked(privacy.content)
-    : "";
 // Transform relative /uploads/ URLs to absolute Strapi URLs
-const htmlContent = transformContentUrls(rawHtml);
+const htmlContent = privacy?.richContent ? transformContentUrls(privacy.richContent) : "";
 
 const title = privacy?.title || "Privacy Policy";
 const lastUpdated = privacy?.lastUpdated


### PR DESCRIPTION
## Summary

Removes the markdown fallback code from frontend pages, using `richContent` field directly:

- Remove `marked` import and markdown-to-HTML conversion from blog, about, and privacy pages
- Use `richContent` field directly without fallback to legacy `content` field
- Update CLAUDE.md to reflect CKEditor-based content storage

## Dependencies

This PR depends on #79 being merged first (backend legacy content field removal).

## Test plan

- [x] Verify blog posts display correctly
- [x] Verify About page displays correctly  
- [x] Verify Privacy Policy page displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)