### PR TITLE
Remove unused marked dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/cloudflare": "^12.6.12",
         "@tailwindcss/vite": "^4.1.3",
         "astro": "^5.17.1",
-        "marked": "^15.0.8",
         "tailwindcss": "^4.1.3"
       },
       "devDependencies": {
@@ -3536,18 +3535,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.8.tgz",
-      "integrity": "sha512-rli4l2LyZqpQuRve5C0rkn6pj3hT8EWPC+zkAxFTAJLxRbENfTAhEQq9itrmf1Y81QtAX5D/MYlGlIomNgj9lA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
     "@astrojs/cloudflare": "^12.6.12",
     "@tailwindcss/vite": "^4.1.3",
     "astro": "^5.17.1",
-    "marked": "^15.0.8",
     "tailwindcss": "^4.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Removes the `marked` library from frontend dependencies since content is now stored as HTML in CKEditor rather than markdown.

## Test plan

- [ ] Verify frontend builds successfully
- [ ] Verify pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)