### PR TITLE
Fix Strapi API token access on Cloudflare Pages

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
 
   env: {
     schema: {
+      STRAPI_API_URL: envField.string({ context: 'server', access: 'public', default: 'https://journal.hillpeople.net' }),
       STRAPI_API_TOKEN: envField.string({ context: 'server', access: 'secret', optional: true }),
     }
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
-import { getSecret } from 'astro:env/server'
+import { getSecret, STRAPI_API_URL } from 'astro:env/server'
 
-const STRAPI_URL = import.meta.env.STRAPI_API_URL
+const STRAPI_URL = STRAPI_API_URL
 
 // Helper to make authenticated requests to Strapi
 async function strapiFetch(url: string): Promise<Response> {


### PR DESCRIPTION
## Summary
- Use Astro's `getSecret()` helper to access runtime secrets on Cloudflare Pages
- Add env schema to astro.config.mjs for the STRAPI_API_TOKEN secret

`import.meta.env` only works for build-time variables. For runtime secrets on Cloudflare Pages, we need to use Astro's `getSecret()` helper which properly accesses the Cloudflare runtime environment.

## Test plan
- [ ] Deploy to Cloudflare Pages
- [ ] Verify pages load without 403 errors
- [ ] Check that climbing log and other pages fetch data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)