### PR TITLE
Add climbing embed support for blog posts (M3)

### DIFF
--- a/backend/src/api/post/content-types/post/schema.json
+++ b/backend/src/api/post/content-types/post/schema.json
@@ -54,6 +54,11 @@
     "newsletterSent": {
       "type": "boolean",
       "default": false
+    },
+    "climbingDateRange": {
+      "type": "component",
+      "repeatable": false,
+      "component": "climbing.date-range"
     }
   }
 }

--- a/backend/src/components/climbing/date-range.json
+++ b/backend/src/components/climbing/date-range.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_climbing_date_ranges",
+  "info": {
+    "displayName": "Climbing Date Range",
+    "icon": "mountain",
+    "description": "Embed climbing ticks from a date range in a blog post"
+  },
+  "options": {},
+  "attributes": {
+    "startDate": {
+      "type": "date",
+      "required": true
+    },
+    "endDate": {
+      "type": "date"
+    },
+    "showClimbingData": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/frontend/src/components/ClimbingEmbed.astro
+++ b/frontend/src/components/ClimbingEmbed.astro
@@ -1,0 +1,97 @@
+---
+import { fetchClimbingTicksByDateRange, type ClimbingTick } from "../lib/api";
+
+interface Props {
+    startDate: string;
+    endDate?: string;
+}
+
+const { startDate, endDate } = Astro.props;
+
+// If no endDate, use startDate for single-day trips
+const effectiveEndDate = endDate || startDate;
+
+const ticks = await fetchClimbingTicksByDateRange(startDate, effectiveEndDate);
+
+// Group ticks by route (deduping multiple climbers)
+interface GroupedRoute {
+    route: ClimbingTick['route'];
+    climbers: string[];
+    bestStars: number;
+}
+
+function groupTicksByRoute(tickList: ClimbingTick[]): GroupedRoute[] {
+    const routeMap = new Map<string, GroupedRoute>();
+
+    for (const tick of tickList) {
+        const routeUrl = tick.route?.mountainProjectUrl || 'unknown';
+
+        if (!routeMap.has(routeUrl)) {
+            routeMap.set(routeUrl, {
+                route: tick.route,
+                climbers: [],
+                bestStars: 0,
+            });
+        }
+
+        const groupedRoute = routeMap.get(routeUrl)!;
+
+        if (tick.person?.name && !groupedRoute.climbers.includes(tick.person.name)) {
+            groupedRoute.climbers.push(tick.person.name);
+        }
+
+        if (tick.yourStars && tick.yourStars > groupedRoute.bestStars) {
+            groupedRoute.bestStars = tick.yourStars;
+        }
+    }
+
+    return Array.from(routeMap.values());
+}
+
+const routes = groupTicksByRoute(ticks);
+---
+
+{routes.length > 0 && (
+    <div class="climbing-embed my-8 p-4 rounded-lg border border-[var(--color-accent)] bg-[var(--color-bg)]">
+        <h3 class="text-lg font-semibold mb-3 text-[var(--color-header)]">
+            Routes Climbed
+        </h3>
+        <div class="space-y-2">
+            {routes.map((groupedRoute) => (
+                <div class="flex items-start gap-4 p-2 rounded border border-[var(--color-accent)] hover:border-[var(--color-header)] transition">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-baseline gap-2 flex-wrap">
+                            <a
+                                href={groupedRoute.route?.mountainProjectUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="font-semibold hover:underline text-[var(--color-header)]"
+                            >
+                                {groupedRoute.route?.name || "Unknown Route"}
+                            </a>
+                            {groupedRoute.route?.rating && (
+                                <span class="text-sm font-mono">{groupedRoute.route.rating}</span>
+                            )}
+                            {groupedRoute.route?.routeType && (
+                                <span class="text-xs opacity-70">{groupedRoute.route.routeType}</span>
+                            )}
+                        </div>
+                        {groupedRoute.route?.location && (
+                            <p class="text-sm truncate">{groupedRoute.route.location}</p>
+                        )}
+                        {groupedRoute.climbers.length > 0 && (
+                            <p class="text-xs mt-1 opacity-70">
+                                {groupedRoute.climbers.join(" & ")}
+                            </p>
+                        )}
+                    </div>
+                    {groupedRoute.bestStars > 0 && (
+                        <div class="flex-shrink-0 text-sm text-[var(--color-header)]" title={`${groupedRoute.bestStars} stars`}>
+                            {"★".repeat(groupedRoute.bestStars)}{"☆".repeat(4 - groupedRoute.bestStars)}
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    </div>
+)}

--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -4,6 +4,7 @@ import Prose from "../../components/Prose.astro";
 import { fetchPostBySlug, fetchSiteSettings } from "../../lib/api";
 import { getMediaUrl, getLargestImage, transformContentUrls } from "../../lib/imageUrl";
 import StravaEmbed from "../../components/StravaEmbed.astro";
+import ClimbingEmbed from "../../components/ClimbingEmbed.astro";
 
 const { slug } = Astro.params;
 
@@ -67,6 +68,15 @@ const siteName = siteSettings?.siteName || "Hill People";
                 <div class="mt-10">
                     <StravaEmbed activityId={post.stravaActivityId} />
                 </div>
+            )
+        }
+
+        {
+            post.climbingDateRange?.showClimbingData && post.climbingDateRange?.startDate && (
+                <ClimbingEmbed
+                    startDate={post.climbingDateRange.startDate}
+                    endDate={post.climbingDateRange.endDate}
+                />
             )
         }
     </article>


### PR DESCRIPTION
## Summary
- Create ClimbingDateRange component in Strapi backend with startDate, endDate (optional), and showClimbingData toggle
- Add climbingDateRange component field to Post schema
- Create ClimbingEmbed.astro component that fetches and displays climbing ticks for a date range
- Update [slug].astro to render ClimbingEmbed when enabled

When editing a post in Strapi, authors can add a climbing date range component to embed routes climbed during that period. If `endDate` is not set, it defaults to `startDate` for single-day trips.

## Test plan
- [x] Run `make backend` to start local Strapi
- [x] Verify the "Climbing Date Range" component appears in Post editor
- [x] Create/edit a post with a date range that overlaps with synced climbing ticks
- [x] Enable `showClimbingData` toggle
- [x] Run frontend dev server and view the post
- [x] Verify ClimbingEmbed renders with correct ticks for the date range

## Related
- Part of Mountain Project integration plan
- Milestone 3: Blog Post Integration

Closes #89 

🤖 Generated with [Claude Code](https://claude.com/claude-code)