### PR TITLE
Display notes in climbing log and embeds

### DIFF
--- a/frontend/src/components/ClimbingEmbed.astro
+++ b/frontend/src/components/ClimbingEmbed.astro
@@ -20,6 +20,7 @@ interface GroupedRoute {
     climbers: string[];
     bestStars: number;
     photos: StrapiImage[];
+    notes: string[];
 }
 
 function groupTicksByRoute(tickList: ClimbingTick[]): GroupedRoute[] {
@@ -34,6 +35,7 @@ function groupTicksByRoute(tickList: ClimbingTick[]): GroupedRoute[] {
                 climbers: [],
                 bestStars: 0,
                 photos: [],
+                notes: [],
             });
         }
 
@@ -54,6 +56,11 @@ function groupTicksByRoute(tickList: ClimbingTick[]): GroupedRoute[] {
                     groupedRoute.photos.push(photo);
                 }
             }
+        }
+
+        // Collect notes (avoid duplicates)
+        if (tick.notes && !groupedRoute.notes.includes(tick.notes)) {
+            groupedRoute.notes.push(tick.notes);
         }
     }
 
@@ -94,6 +101,11 @@ const routes = groupTicksByRoute(ticks);
                         {groupedRoute.climbers.length > 0 && (
                             <p class="text-xs mt-1 opacity-70">
                                 {groupedRoute.climbers.join(" & ")}
+                            </p>
+                        )}
+                        {groupedRoute.notes.length > 0 && (
+                            <p class="text-sm mt-2 italic opacity-80">
+                                {groupedRoute.notes.join(" · ")}
                             </p>
                         )}
                         <PhotoGallery

--- a/frontend/src/pages/climbing.astro
+++ b/frontend/src/pages/climbing.astro
@@ -28,6 +28,7 @@ interface GroupedRoute {
     climbers: string[];
     bestStars: number;
     photos: StrapiImage[];
+    notes: string[];
 }
 
 // Group ticks by date, then by route (deduping multiple climbers)
@@ -56,6 +57,7 @@ function groupTicksByDateAndRoute(tickList: ClimbingTick[]): TicksByDate[] {
                 climbers: [],
                 bestStars: 0,
                 photos: [],
+                notes: [],
             });
         }
 
@@ -79,6 +81,11 @@ function groupTicksByDateAndRoute(tickList: ClimbingTick[]): TicksByDate[] {
                     groupedRoute.photos.push(photo);
                 }
             }
+        }
+
+        // Collect notes (avoid duplicates)
+        if (tick.notes && !groupedRoute.notes.includes(tick.notes)) {
+            groupedRoute.notes.push(tick.notes);
         }
     }
 
@@ -143,6 +150,11 @@ const uniqueRouteCount = ticksByDate.reduce((sum, day) => sum + day.routes.lengt
                                     {groupedRoute.climbers.length > 0 && (
                                         <p class="text-xs mt-1 opacity-70">
                                             {groupedRoute.climbers.join(" & ")}
+                                        </p>
+                                    )}
+                                    {groupedRoute.notes.length > 0 && (
+                                        <p class="text-sm mt-2 italic opacity-80">
+                                            {groupedRoute.notes.join(" · ")}
                                         </p>
                                     )}
                                     <PhotoGallery


### PR DESCRIPTION
## Summary
Display notes from Strapi in the climbing log page and blog post embeds.

Notes appear in italic below the climber names. When multiple climbers have different notes for the same route, they are joined with " · ".

## Changes
- Add `notes` field to `GroupedRoute` interface in both files
- Collect unique notes when grouping ticks by route
- Render notes in italic with `opacity-80` styling

## Test plan
- [x] Add/edit notes on a climbing tick in Strapi admin
- [x] Visit `/climbing` and verify notes appear below climber names
- [x] Test a blog post with climbing embed to verify notes display there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)