### PR TITLE
Redesign climbing page as The Ticklist

### DIFF
--- a/backend/src/api/climbing-goal/content-types/climbing-goal/schema.json
+++ b/backend/src/api/climbing-goal/content-types/climbing-goal/schema.json
@@ -1,0 +1,53 @@
+{
+  "kind": "collectionType",
+  "collectionName": "climbing_goals",
+  "info": {
+    "singularName": "climbing-goal",
+    "pluralName": "climbing-goals",
+    "displayName": "Climbing Goal",
+    "description": "Climbing goals for tracking progress"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "person": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::person.person"
+    },
+    "year": {
+      "type": "integer",
+      "required": true
+    },
+    "goalType": {
+      "type": "enumeration",
+      "enum": [
+        "lead_pitches",
+        "lead_climbs",
+        "redpoints",
+        "onsights",
+        "grade_target"
+      ],
+      "required": true
+    },
+    "targetCount": {
+      "type": "integer",
+      "required": true
+    },
+    "minGrade": {
+      "type": "string"
+    },
+    "routeType": {
+      "type": "string"
+    },
+    "isActive": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/backend/src/api/climbing-goal/controllers/climbing-goal.ts
+++ b/backend/src/api/climbing-goal/controllers/climbing-goal.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::climbing-goal.climbing-goal');

--- a/backend/src/api/climbing-goal/routes/climbing-goal.ts
+++ b/backend/src/api/climbing-goal/routes/climbing-goal.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::climbing-goal.climbing-goal');

--- a/backend/src/api/climbing-goal/services/climbing-goal.ts
+++ b/backend/src/api/climbing-goal/services/climbing-goal.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::climbing-goal.climbing-goal');

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -466,6 +466,46 @@ export interface ApiAboutAbout extends Struct.SingleTypeSchema {
   };
 }
 
+export interface ApiClimbingGoalClimbingGoal
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'climbing_goals';
+  info: {
+    description: 'Climbing goals for tracking progress';
+    displayName: 'Climbing Goal';
+    pluralName: 'climbing-goals';
+    singularName: 'climbing-goal';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    goalType: Schema.Attribute.Enumeration<
+      ['lead_pitches', 'lead_climbs', 'redpoints', 'onsights', 'grade_target']
+    > &
+      Schema.Attribute.Required;
+    isActive: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<true>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::climbing-goal.climbing-goal'
+    > &
+      Schema.Attribute.Private;
+    minGrade: Schema.Attribute.String;
+    person: Schema.Attribute.Relation<'manyToOne', 'api::person.person'>;
+    publishedAt: Schema.Attribute.DateTime;
+    routeType: Schema.Attribute.String;
+    targetCount: Schema.Attribute.Integer & Schema.Attribute.Required;
+    title: Schema.Attribute.String & Schema.Attribute.Required;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    year: Schema.Attribute.Integer & Schema.Attribute.Required;
+  };
+}
+
 export interface ApiClimbingRouteClimbingRoute
   extends Struct.CollectionTypeSchema {
   collectionName: 'climbing_routes';
@@ -1383,6 +1423,7 @@ declare module '@strapi/strapi' {
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'admin::user': AdminUser;
       'api::about.about': ApiAboutAbout;
+      'api::climbing-goal.climbing-goal': ApiClimbingGoalClimbingGoal;
       'api::climbing-route.climbing-route': ApiClimbingRouteClimbingRoute;
       'api::climbing-tick.climbing-tick': ApiClimbingTickClimbingTick;
       'api::home-page.home-page': ApiHomePageHomePage;

--- a/frontend/src/components/GoalsDashboard.astro
+++ b/frontend/src/components/GoalsDashboard.astro
@@ -1,0 +1,55 @@
+---
+import ProgressBar from './charts/ProgressBar.astro';
+import type { GoalProgress } from '../lib/tickStats';
+
+interface Props {
+    goals: GoalProgress[];
+    personName?: string;
+    goalYear?: number;
+}
+
+const { goals, personName, goalYear } = Astro.props;
+
+// Sort goals: incomplete first, then by percent descending
+const sortedGoals = [...goals].sort((a, b) => {
+    if (a.isComplete !== b.isComplete) {
+        return a.isComplete ? 1 : -1; // Incomplete first
+    }
+    return b.percent - a.percent; // Higher percent first
+});
+
+const completedCount = goals.filter(g => g.isComplete).length;
+const allComplete = completedCount === goals.length && goals.length > 0;
+---
+
+{goals.length > 0 && (
+    <div class="goals-dashboard bg-[var(--color-accent)]/5 rounded-xl p-6 mb-8">
+        <div class="flex items-center justify-between mb-4">
+            <h2 class="text-xl font-bold">
+                {personName ? `${personName}'s ${goalYear || ''} Goals` : `${goalYear || ''} Goals`}
+            </h2>
+            {allComplete && (
+                <span class="text-sm bg-green-100 text-green-800 px-3 py-1 rounded-full">
+                    All goals complete! 🎉
+                </span>
+            )}
+            {!allComplete && completedCount > 0 && (
+                <span class="text-sm opacity-70">
+                    {completedCount} of {goals.length} complete
+                </span>
+            )}
+        </div>
+
+        <div class="goals-list">
+            {sortedGoals.map(progress => (
+                <ProgressBar
+                    title={progress.goal.title}
+                    current={progress.current}
+                    target={progress.target}
+                    percent={progress.percent}
+                    isComplete={progress.isComplete}
+                />
+            ))}
+        </div>
+    </div>
+)}

--- a/frontend/src/components/StatsCards.astro
+++ b/frontend/src/components/StatsCards.astro
@@ -1,0 +1,63 @@
+---
+import type { TickStats } from '../lib/tickStats';
+
+interface Props {
+    stats: TickStats;
+}
+
+const { stats } = Astro.props;
+
+const cards = [
+    {
+        label: 'Routes Climbed',
+        value: stats.totalTicks,
+    },
+    {
+        label: 'Lead Pitches',
+        value: stats.leadPitches,
+    },
+    {
+        label: 'Days Outside',
+        value: stats.uniqueDays,
+    },
+    {
+        label: 'Highest Redpoint',
+        value: stats.highestRedpoint || '—',
+    },
+];
+---
+
+<div class="stats-cards grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+    {cards.map((card, i) => (
+        <div
+            class="stat-card bg-[var(--color-accent)]/10 rounded-lg p-4 text-center transition-transform hover:scale-105"
+            style={`--card-index: ${i};`}
+        >
+            <div class="text-2xl font-bold text-[var(--color-header)]">{card.value}</div>
+            <div class="text-sm opacity-70">{card.label}</div>
+        </div>
+    ))}
+</div>
+
+{stats.favoriteArea && (
+    <div class="favorite-area text-center mb-8 opacity-80">
+        <span class="text-sm">Most climbed area: </span>
+        <span class="font-semibold">{stats.favoriteArea}</span>
+    </div>
+)}
+
+<style>
+    .stat-card {
+        animation: fade-up 0.5s ease-out forwards;
+        animation-delay: calc(var(--card-index, 0) * 100ms);
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    @keyframes fade-up {
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+</style>

--- a/frontend/src/components/TicklistFilters.astro
+++ b/frontend/src/components/TicklistFilters.astro
@@ -1,0 +1,80 @@
+---
+import type { Person } from '../lib/api';
+
+interface Props {
+    people: Person[];
+    selectedPersonId?: string;
+    selectedYear?: number;
+    showAllTime?: boolean;
+    showLast12Months?: boolean;
+    availableYears: number[];
+}
+
+const { people, selectedPersonId, selectedYear, showAllTime, showLast12Months, availableYears } = Astro.props;
+---
+
+<div class="ticklist-filters flex flex-wrap gap-4 mb-8 items-center">
+    <!-- Person Filter -->
+    <div class="filter-group">
+        <label for="person-filter" class="text-sm opacity-70 mr-2">Climber:</label>
+        <select
+            id="person-filter"
+            class="px-3 py-2 rounded-lg border border-[var(--color-accent)] bg-[var(--color-bg)] text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-header)]"
+        >
+            <option value="" selected={!selectedPersonId}>Everyone</option>
+            {people.map(person => (
+                <option value={person.documentId} selected={selectedPersonId === person.documentId}>
+                    {person.name}
+                </option>
+            ))}
+        </select>
+    </div>
+
+    <!-- Year Filter -->
+    <div class="filter-group">
+        <label for="year-filter" class="text-sm opacity-70 mr-2">Period:</label>
+        <select
+            id="year-filter"
+            class="px-3 py-2 rounded-lg border border-[var(--color-accent)] bg-[var(--color-bg)] text-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-[var(--color-header)]"
+        >
+            <option value="last12" selected={showLast12Months}>Last 12 Months</option>
+            <option value="all" selected={showAllTime}>All Time</option>
+            {availableYears.map(year => (
+                <option value={year} selected={!showAllTime && !showLast12Months && selectedYear === year}>
+                    {year}
+                </option>
+            ))}
+        </select>
+    </div>
+</div>
+
+<script>
+    const personFilter = document.getElementById('person-filter') as HTMLSelectElement;
+    const yearFilter = document.getElementById('year-filter') as HTMLSelectElement;
+
+    function updateFilters() {
+        const personId = personFilter?.value || '';
+        const year = yearFilter?.value || 'last12';
+
+        const url = new URL(window.location.href);
+
+        if (personId) {
+            url.searchParams.set('person', personId);
+        } else {
+            url.searchParams.delete('person');
+        }
+
+        if (year === 'all') {
+            url.searchParams.set('year', 'all');
+        } else if (year === 'last12') {
+            url.searchParams.delete('year');
+        } else {
+            url.searchParams.set('year', year);
+        }
+
+        window.location.href = url.toString();
+    }
+
+    personFilter?.addEventListener('change', updateFilters);
+    yearFilter?.addEventListener('change', updateFilters);
+</script>

--- a/frontend/src/components/charts/BarChart.astro
+++ b/frontend/src/components/charts/BarChart.astro
@@ -1,0 +1,264 @@
+---
+interface ActivityData {
+    label: string;
+    climbs: number;
+    pitches: number;
+}
+
+interface Props {
+    data: ActivityData[];
+    title?: string;
+    height?: number;
+    barColor?: string;
+}
+
+const { data, title, height = 200, barColor = 'var(--color-header)' } = Astro.props;
+
+// Calculate max values for scaling
+const maxPitches = Math.max(...data.map(d => d.pitches), 1);
+const maxClimbs = Math.max(...data.map(d => d.climbs), 1);
+---
+
+<div class="bar-chart-container" data-mode="pitches">
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
+        {title && <h3 class="text-lg font-semibold">{title}</h3>}
+        <div class="bar-chart-toggle flex gap-1 text-xs" role="group" aria-label="Activity metric">
+            <button
+                type="button"
+                class="bar-toggle-btn active"
+                data-mode="pitches"
+                aria-pressed="true"
+            >
+                Pitches
+            </button>
+            <button
+                type="button"
+                class="bar-toggle-btn"
+                data-mode="climbs"
+                aria-pressed="false"
+            >
+                Climbs
+            </button>
+        </div>
+    </div>
+
+    <div class="bar-chart" style={`min-height: ${height}px;`}>
+        <!-- Grid lines -->
+        <div class="chart-grid">
+            <div class="grid-line"></div>
+            <div class="grid-line"></div>
+            <div class="grid-line"></div>
+        </div>
+
+        <!-- Pitches bars (shown by default) -->
+        <div class="bars-group pitches-bars">
+            {data.map((point) => {
+                const heightPercent = maxPitches > 0 ? (point.pitches / maxPitches) * 100 : 0;
+                return (
+                    <div class="bar-column">
+                        <div
+                            class="bar"
+                            style={`height: ${heightPercent}%; background-color: ${barColor};`}
+                        >
+                            <span class="bar-tooltip">{point.pitches} pitches</span>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+
+        <!-- Climbs bars (hidden by default) -->
+        <div class="bars-group climbs-bars">
+            {data.map((point) => {
+                const heightPercent = maxClimbs > 0 ? (point.climbs / maxClimbs) * 100 : 0;
+                return (
+                    <div class="bar-column">
+                        <div
+                            class="bar"
+                            style={`height: ${heightPercent}%; background-color: ${barColor};`}
+                        >
+                            <span class="bar-tooltip">{point.climbs} climbs</span>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+
+        <!-- X-axis labels -->
+        <div class="x-labels">
+            {data.map(point => (
+                <span class="x-label">{point.label}</span>
+            ))}
+        </div>
+    </div>
+</div>
+
+<style>
+    .bar-chart-container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .bar-toggle-btn {
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.25rem;
+        transition: background-color 0.2s, color 0.2s;
+        background-color: #d4d4d4;
+        color: #555;
+    }
+
+    .bar-toggle-btn.active {
+        background-color: var(--color-header);
+        color: white;
+    }
+
+    .bar-toggle-btn:hover:not(.active),
+    .bar-toggle-btn:focus:not(.active) {
+        background-color: #bbb;
+    }
+
+    :global(.dark) .bar-toggle-btn {
+        background-color: #444;
+        color: #ccc;
+    }
+
+    :global(.dark) .bar-toggle-btn:hover:not(.active),
+    :global(.dark) .bar-toggle-btn:focus:not(.active) {
+        background-color: #555;
+    }
+
+    .bar-toggle-btn:focus {
+        outline: 2px solid var(--color-header);
+        outline-offset: 2px;
+    }
+
+    .bar-chart {
+        position: relative;
+        flex: 1;
+    }
+
+    .chart-grid {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        padding-bottom: 30px;
+        pointer-events: none;
+        opacity: 0.3;
+    }
+
+    .grid-line {
+        border-bottom: 1px solid currentColor;
+    }
+
+    .bars-group {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 30px; /* Leave space for x-labels */
+        display: grid;
+        grid-auto-columns: 1fr;
+        grid-auto-flow: column;
+        gap: 4px;
+    }
+
+    /* Toggle visibility based on container's data-mode */
+    .bar-chart-container[data-mode="pitches"] .pitches-bars {
+        display: grid;
+    }
+    .bar-chart-container[data-mode="pitches"] .climbs-bars {
+        display: none;
+    }
+    .bar-chart-container[data-mode="climbs"] .pitches-bars {
+        display: none;
+    }
+    .bar-chart-container[data-mode="climbs"] .climbs-bars {
+        display: grid;
+    }
+
+    .bar-column {
+        height: 100%;
+        display: flex;
+        align-items: flex-end;
+    }
+
+    .bar {
+        width: 100%;
+        min-height: 4px;
+        border-radius: 4px 4px 0 0;
+        transition: opacity 0.2s;
+        position: relative;
+        cursor: pointer;
+    }
+
+    .bar:hover {
+        opacity: 0.8;
+    }
+
+    .bar-tooltip {
+        position: absolute;
+        top: -32px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: var(--color-text);
+        color: var(--color-bg);
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        white-space: nowrap;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s;
+    }
+
+    .bar:hover .bar-tooltip {
+        opacity: 1;
+    }
+
+    .x-labels {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+    }
+
+    .x-label {
+        flex: 1;
+        text-align: center;
+        font-size: 0.75rem;
+        opacity: 0.7;
+    }
+</style>
+
+<script>
+    function initBarChartToggles() {
+        document.querySelectorAll('.bar-chart-container').forEach(container => {
+            const buttons = container.querySelectorAll('.bar-toggle-btn');
+
+            buttons.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const mode = btn.getAttribute('data-mode');
+                    if (!mode) return;
+
+                    // Update container's data-mode (CSS handles the rest)
+                    container.setAttribute('data-mode', mode);
+
+                    // Update button states
+                    buttons.forEach(b => {
+                        const isActive = b.getAttribute('data-mode') === mode;
+                        b.classList.toggle('active', isActive);
+                        b.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+                    });
+                });
+            });
+        });
+    }
+
+    initBarChartToggles();
+    document.addEventListener('astro:page-load', initBarChartToggles);
+</script>

--- a/frontend/src/components/charts/DonutChart.astro
+++ b/frontend/src/components/charts/DonutChart.astro
@@ -1,0 +1,146 @@
+---
+interface DataPoint {
+    label: string;
+    value: number;
+    color?: string;
+}
+
+interface Props {
+    data: DataPoint[];
+    title?: string;
+    size?: number;
+    strokeWidth?: number;
+}
+
+const { data, title, size = 200, strokeWidth = 40 } = Astro.props;
+
+// Filter out zero values and calculate total
+const filteredData = data.filter(d => d.value > 0);
+const total = filteredData.reduce((sum, d) => sum + d.value, 0);
+
+// Default colors if not provided
+const defaultColors = [
+    'var(--color-header)',      // Coral
+    'var(--color-accent)',      // Teal
+    '#d77a40',                  // Orange
+    '#8a8a6c',                  // Olive
+    '#b5855a',                  // Tan
+    '#5e413b',                  // Brown
+];
+
+// Calculate SVG dimensions
+const viewBoxSize = 100;
+const center = viewBoxSize / 2;
+const radius = (viewBoxSize - strokeWidth / 2) / 2 - 5;
+const circumference = 2 * Math.PI * radius;
+
+// Calculate segment positions
+let currentOffset = 0;
+const segments = filteredData.map((item, i) => {
+    const percent = item.value / total;
+    const segmentLength = circumference * percent;
+    const segment = {
+        ...item,
+        color: item.color || defaultColors[i % defaultColors.length],
+        offset: currentOffset,
+        length: segmentLength,
+        percent: Math.round(percent * 100),
+    };
+    currentOffset += segmentLength;
+    return segment;
+});
+---
+
+<div class="donut-container">
+    {title && <h3 class="text-lg font-semibold mb-4 text-center">{title}</h3>}
+
+    <div class="flex flex-col sm:flex-row items-center gap-6">
+        <!-- SVG Donut -->
+        <div class="relative" style={`width: ${size}px; height: ${size}px;`}>
+            <svg
+                viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+                class="donut-svg transform -rotate-90"
+                style={`width: ${size}px; height: ${size}px;`}
+            >
+                {/* Background circle */}
+                <circle
+                    cx={center}
+                    cy={center}
+                    r={radius}
+                    fill="none"
+                    stroke="var(--color-accent)"
+                    stroke-opacity="0.2"
+                    stroke-width={strokeWidth / 5}
+                />
+
+                {/* Data segments */}
+                {segments.map((segment, i) => (
+                    <circle
+                        cx={center}
+                        cy={center}
+                        r={radius}
+                        fill="none"
+                        stroke={segment.color}
+                        stroke-width={strokeWidth / 5}
+                        stroke-dasharray={`${segment.length} ${circumference - segment.length}`}
+                        stroke-dashoffset={-segment.offset}
+                        class="donut-segment"
+                        data-index={i}
+                        style={`--segment-index: ${i};`}
+                    />
+                ))}
+            </svg>
+
+            <!-- Center text -->
+            <div class="absolute inset-0 flex flex-col items-center justify-center">
+                <span class="text-2xl font-bold">{total}</span>
+                <span class="text-xs opacity-70">total</span>
+            </div>
+        </div>
+
+        <!-- Legend -->
+        <div class="legend flex flex-col gap-2">
+            {segments.map(segment => (
+                <div class="flex items-center gap-2">
+                    <span
+                        class="w-3 h-3 rounded-full shrink-0"
+                        style={`background-color: ${segment.color};`}
+                    ></span>
+                    <span class="text-sm">
+                        {segment.label}
+                        <span class="opacity-70 ml-1">({segment.value})</span>
+                    </span>
+                </div>
+            ))}
+        </div>
+    </div>
+
+    {filteredData.length === 0 && (
+        <p class="text-center opacity-60 py-4">No data available</p>
+    )}
+</div>
+
+<style>
+    .donut-segment {
+        transform-origin: center;
+        animation: draw-segment 1s ease-out forwards;
+        animation-delay: calc(var(--segment-index, 0) * 150ms);
+        stroke-dasharray: 0 1000;
+    }
+
+    @keyframes draw-segment {
+        to {
+            stroke-dasharray: var(--final-dash);
+        }
+    }
+</style>
+
+<script>
+    // Set final dasharray for animation
+    document.querySelectorAll('.donut-segment').forEach(segment => {
+        const dashArray = segment.getAttribute('stroke-dasharray');
+        if (dashArray) {
+            (segment as HTMLElement).style.setProperty('--final-dash', dashArray);
+        }
+    });
+</script>

--- a/frontend/src/components/charts/GradePyramid.astro
+++ b/frontend/src/components/charts/GradePyramid.astro
@@ -1,0 +1,337 @@
+---
+interface GradeData {
+    grade: string;
+    count: number;
+}
+
+interface Props {
+    allRoutes: GradeData[];
+    leads: GradeData[];
+    redpoints: GradeData[];
+    title?: string;
+    maxWidth?: number;
+}
+
+const { allRoutes, leads, redpoints, title, maxWidth = 400 } = Astro.props;
+
+// Colors for the pyramid (gradient from teal to coral)
+const colors = [
+    'var(--color-header)',      // Highest grade - coral
+    '#d77a40',                  // Orange
+    '#b5855a',                  // Tan
+    '#8a8a6c',                  // Olive
+    'var(--color-accent)',      // Teal
+];
+
+// Serialize data for client-side use
+const pyramidData = JSON.stringify({ allRoutes, leads, redpoints });
+
+// Mode descriptions for tooltips
+const modeDescriptions = {
+    redpoints: 'Lead, no falls',
+    leads: 'All lead climbs',
+    allRoutes: 'All routes including top rope and follows',
+};
+---
+
+<div class="pyramid-container">
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
+        {title && <h3 class="text-lg font-semibold">{title}</h3>}
+        <div class="pyramid-mode-toggle flex gap-1 text-xs" role="group" aria-label="Grade pyramid filter">
+            <div class="mode-btn-wrapper relative">
+                <button
+                    type="button"
+                    class="pyramid-mode-btn px-2 py-1 rounded transition-colors"
+                    data-mode="redpoints"
+                    aria-pressed="false"
+                    aria-describedby="tooltip-redpoints"
+                >
+                    Hardo
+                </button>
+                <span
+                    id="tooltip-redpoints"
+                    class="pyramid-tooltip"
+                    role="tooltip"
+                >
+                    {modeDescriptions.redpoints}
+                </span>
+            </div>
+            <div class="mode-btn-wrapper relative">
+                <button
+                    type="button"
+                    class="pyramid-mode-btn px-2 py-1 rounded transition-colors active"
+                    data-mode="leads"
+                    aria-pressed="true"
+                    aria-describedby="tooltip-leads"
+                >
+                    Normal
+                </button>
+                <span
+                    id="tooltip-leads"
+                    class="pyramid-tooltip"
+                    role="tooltip"
+                >
+                    {modeDescriptions.leads}
+                </span>
+            </div>
+            <div class="mode-btn-wrapper relative">
+                <button
+                    type="button"
+                    class="pyramid-mode-btn px-2 py-1 rounded transition-colors"
+                    data-mode="allRoutes"
+                    aria-pressed="false"
+                    aria-describedby="tooltip-allRoutes"
+                >
+                    Top Rope Tough Guy
+                </button>
+                <span
+                    id="tooltip-allRoutes"
+                    class="pyramid-tooltip"
+                    role="tooltip"
+                >
+                    {modeDescriptions.allRoutes}
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <div
+        class="pyramid flex flex-col items-center gap-1"
+        style={`max-width: ${maxWidth}px; margin: 0 auto;`}
+        data-pyramid-data={pyramidData}
+        data-colors={JSON.stringify(colors)}
+    >
+        <!-- Pyramid rows will be rendered by JavaScript -->
+    </div>
+
+    <div class="pyramid-empty text-center opacity-60 py-4 hidden">
+        No grade data available
+    </div>
+</div>
+
+<style>
+    .pyramid-mode-btn {
+        background-color: #d4d4d4;
+        color: #555;
+    }
+
+    .pyramid-mode-btn.active {
+        background-color: var(--color-header);
+        color: white;
+    }
+
+    .pyramid-mode-btn:hover:not(.active),
+    .pyramid-mode-btn:focus:not(.active) {
+        background-color: #bbb;
+    }
+
+    :global(.dark) .pyramid-mode-btn {
+        background-color: #444;
+        color: #ccc;
+    }
+
+    :global(.dark) .pyramid-mode-btn:hover:not(.active),
+    :global(.dark) .pyramid-mode-btn:focus:not(.active) {
+        background-color: #555;
+    }
+
+    .pyramid-mode-btn:focus {
+        outline: 2px solid var(--color-header);
+        outline-offset: 2px;
+    }
+
+    .mode-btn-wrapper {
+        position: relative;
+    }
+
+    .pyramid-tooltip {
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 0.5rem 0.75rem;
+        background-color: var(--color-text);
+        color: var(--color-bg);
+        font-size: 0.75rem;
+        line-height: 1.2;
+        border-radius: 0.375rem;
+        white-space: nowrap;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.15s, visibility 0.15s;
+        pointer-events: none;
+        z-index: 10;
+        margin-bottom: 0.5rem;
+    }
+
+    .pyramid-tooltip::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border: 6px solid transparent;
+        border-top-color: var(--color-text);
+    }
+
+    /* Show tooltip on hover (desktop) */
+    .mode-btn-wrapper:hover .pyramid-tooltip,
+    .pyramid-mode-btn:focus + .pyramid-tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    /* Show tooltip when button has show-tooltip class (mobile tap) */
+    .mode-btn-wrapper.show-tooltip .pyramid-tooltip {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    .pyramid-bar {
+        transform-origin: left;
+        animation: grow-pyramid 0.6s ease-out forwards;
+        animation-delay: calc(var(--row-index, 0) * 80ms);
+    }
+
+    @keyframes grow-pyramid {
+        from {
+            transform: scaleX(0);
+        }
+        to {
+            transform: scaleX(1);
+        }
+    }
+
+    /* Mobile: make tooltips wider and allow wrapping */
+    @media (max-width: 640px) {
+        .pyramid-tooltip {
+            white-space: normal;
+            max-width: 150px;
+            text-align: center;
+        }
+
+        /* Position rightmost tooltip to the left to avoid overflow */
+        .mode-btn-wrapper:last-child .pyramid-tooltip {
+            left: auto;
+            right: 0;
+            transform: none;
+        }
+
+        .mode-btn-wrapper:last-child .pyramid-tooltip::after {
+            left: auto;
+            right: 1rem;
+            transform: none;
+        }
+    }
+</style>
+
+<script>
+    function initPyramid() {
+        const container = document.querySelector('.pyramid') as HTMLElement;
+        const emptyMsg = document.querySelector('.pyramid-empty') as HTMLElement;
+        const buttons = document.querySelectorAll('.pyramid-mode-btn');
+        const wrappers = document.querySelectorAll('.mode-btn-wrapper');
+
+        if (!container) return;
+
+        const pyramidData = JSON.parse(container.dataset.pyramidData || '{}');
+        const colors = JSON.parse(container.dataset.colors || '[]');
+
+        // Mobile tooltip handling - show on first tap, activate on second
+        let lastTappedWrapper: Element | null = null;
+
+        wrappers.forEach(wrapper => {
+            const btn = wrapper.querySelector('.pyramid-mode-btn');
+            if (!btn) return;
+
+            btn.addEventListener('click', (e) => {
+                // Check if this is a touch device and tooltip isn't showing
+                const isTouchDevice = 'ontouchstart' in window;
+
+                if (isTouchDevice && !wrapper.classList.contains('show-tooltip') && !btn.classList.contains('active')) {
+                    // First tap on inactive button: show tooltip
+                    e.preventDefault();
+                    wrappers.forEach(w => w.classList.remove('show-tooltip'));
+                    wrapper.classList.add('show-tooltip');
+                    lastTappedWrapper = wrapper;
+
+                    // Hide tooltip after 2 seconds
+                    setTimeout(() => {
+                        wrapper.classList.remove('show-tooltip');
+                    }, 2000);
+                } else {
+                    // Second tap or non-touch: activate the mode
+                    wrapper.classList.remove('show-tooltip');
+                    const mode = btn.getAttribute('data-mode') || 'leads';
+                    setActiveMode(mode);
+                }
+            });
+        });
+
+        // Hide tooltips when clicking elsewhere
+        document.addEventListener('click', (e) => {
+            if (lastTappedWrapper && !lastTappedWrapper.contains(e.target as Node)) {
+                lastTappedWrapper.classList.remove('show-tooltip');
+                lastTappedWrapper = null;
+            }
+        });
+
+        function renderPyramid(data: Array<{ grade: string; count: number }>) {
+            if (!data || data.length === 0) {
+                container.innerHTML = '';
+                emptyMsg?.classList.remove('hidden');
+                return;
+            }
+
+            emptyMsg?.classList.add('hidden');
+            const maxValue = Math.max(...data.map(d => d.count), 1);
+            const isDark = document.documentElement.classList.contains('dark');
+            const countColor = isDark ? '#ddd' : '#444';
+
+            container.innerHTML = data.slice(0, 15).map((item, i) => {
+                const widthPercent = maxValue > 0 ? (item.count / maxValue) * 100 : 0;
+                const colorIndex = Math.min(i, colors.length - 1);
+
+                return `
+                    <div class="pyramid-row flex items-center w-full gap-2 group cursor-pointer" data-index="${i}">
+                        <span class="grade-label w-12 text-right text-sm font-mono opacity-80 shrink-0">
+                            ${item.grade}
+                        </span>
+                        <div class="flex-1 h-6 flex items-center gap-2">
+                            <div
+                                class="pyramid-bar h-full rounded-r transition-all duration-500 ease-out group-hover:opacity-80"
+                                style="width: ${Math.max(widthPercent, 2)}%; background-color: ${colors[colorIndex]}; min-width: 4px; --row-index: ${i};"
+                            ></div>
+                            ${item.count > 0 ? `<span class="text-xs font-medium shrink-0" style="color: ${countColor};">${item.count}</span>` : ''}
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function setActiveMode(mode: string) {
+            buttons.forEach(btn => {
+                const isActive = btn.getAttribute('data-mode') === mode;
+                if (isActive) {
+                    btn.classList.add('active');
+                    btn.setAttribute('aria-pressed', 'true');
+                } else {
+                    btn.classList.remove('active');
+                    btn.setAttribute('aria-pressed', 'false');
+                }
+            });
+
+            const data = pyramidData[mode] || [];
+            renderPyramid(data);
+        }
+
+        // Initial render with default mode (leads/Normal)
+        setActiveMode('leads');
+    }
+
+    // Run on page load
+    initPyramid();
+
+    // Re-run on Astro page transitions
+    document.addEventListener('astro:page-load', initPyramid);
+</script>

--- a/frontend/src/components/charts/ProgressBar.astro
+++ b/frontend/src/components/charts/ProgressBar.astro
@@ -1,0 +1,61 @@
+---
+interface Props {
+    title: string;
+    current: number;
+    target: number;
+    percent: number;
+    isComplete: boolean;
+    color?: string;
+}
+
+const { title, current, target, percent, isComplete, color = 'var(--color-header)' } = Astro.props;
+---
+
+<div class="progress-container mb-4">
+    <div class="flex justify-between items-baseline mb-1">
+        <span class="font-semibold text-sm">{title}</span>
+        <span class="text-sm opacity-70">
+            {current} / {target}
+            {isComplete && <span class="ml-1">🎉</span>}
+        </span>
+    </div>
+    <div class="progress-track h-3 rounded-full bg-[var(--color-accent)]/20 overflow-hidden">
+        <div
+            class="progress-fill h-full rounded-full transition-all duration-1000 ease-out"
+            style={`width: ${percent}%; background-color: ${isComplete ? 'var(--color-success, #22c55e)' : color};`}
+            data-target-width={percent}
+        ></div>
+    </div>
+</div>
+
+<style>
+    .progress-fill {
+        width: 0;
+        animation: fill-progress 1s ease-out forwards;
+        animation-delay: 0.2s;
+    }
+
+    @keyframes fill-progress {
+        to {
+            width: var(--target-width);
+        }
+    }
+</style>
+
+<script>
+    // Animate progress bars when they come into view
+    const progressBars = document.querySelectorAll('.progress-fill');
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const bar = entry.target as HTMLElement;
+                const targetWidth = bar.dataset.targetWidth || '0';
+                bar.style.setProperty('--target-width', `${targetWidth}%`);
+                observer.unobserve(bar);
+            }
+        });
+    }, { threshold: 0.1 });
+
+    progressBars.forEach(bar => observer.observe(bar));
+</script>

--- a/frontend/src/lib/tickStats.ts
+++ b/frontend/src/lib/tickStats.ts
@@ -1,0 +1,362 @@
+import type { ClimbingTick, ClimbingGoal, GoalType } from './api';
+
+export interface TickStats {
+    totalTicks: number;
+    totalPitches: number;
+    leadCount: number;
+    leadPitches: number;
+    redpointCount: number;
+    onsightCount: number;
+    flashCount: number;
+    byGrade: Record<string, number>;
+    byGradeLeads: Record<string, number>;
+    byGradeRedpoints: Record<string, number>;
+    byRouteType: Record<string, number>;
+    byMonth: Record<string, number>;
+    pitchesByMonth: Record<string, number>;
+    multipitchCount: number;
+    singlepitchCount: number;
+    uniqueDays: number;
+    highestRedpoint: string;
+    favoriteArea: string;
+}
+
+// YDS grade order for comparison (5.0 to 5.15d)
+const GRADE_ORDER: string[] = [
+    '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9',
+    '5.10a', '5.10b', '5.10c', '5.10d', '5.10',
+    '5.11a', '5.11b', '5.11c', '5.11d', '5.11',
+    '5.12a', '5.12b', '5.12c', '5.12d', '5.12',
+    '5.13a', '5.13b', '5.13c', '5.13d', '5.13',
+    '5.14a', '5.14b', '5.14c', '5.14d', '5.14',
+    '5.15a', '5.15b', '5.15c', '5.15d', '5.15',
+];
+
+/**
+ * Parse a YDS grade string to a numeric value for comparison
+ * Returns -1 for non-YDS grades (bouldering, aid, etc.)
+ */
+export function parseGrade(rating: string): number {
+    if (!rating) return -1;
+
+    // Extract the base YDS grade (e.g., "5.10a" from "5.10a PG13")
+    const match = rating.match(/5\.\d+[a-d]?/i);
+    if (!match) return -1;
+
+    const grade = match[0].toLowerCase();
+    const index = GRADE_ORDER.indexOf(grade);
+
+    // Handle grades without letter suffix (5.10, 5.11, etc.)
+    if (index === -1) {
+        // Try without the letter
+        const baseMatch = rating.match(/5\.\d+/);
+        if (baseMatch) {
+            return GRADE_ORDER.indexOf(baseMatch[0]);
+        }
+    }
+
+    return index;
+}
+
+/**
+ * Check if a grade is at or above a minimum grade threshold
+ */
+export function isGradeAtOrAbove(rating: string, minGrade: string): boolean {
+    const ratingValue = parseGrade(rating);
+    const minValue = parseGrade(minGrade);
+
+    if (ratingValue === -1 || minValue === -1) return false;
+    return ratingValue >= minValue;
+}
+
+/**
+ * Get the display-friendly grade from a rating string
+ */
+export function extractGrade(rating: string): string {
+    if (!rating) return 'Unknown';
+    const match = rating.match(/5\.\d+[a-d]?/i);
+    return match ? match[0] : rating.split(' ')[0];
+}
+
+/**
+ * Compute comprehensive stats from a list of climbing ticks
+ */
+export function computeTickStats(ticks: ClimbingTick[]): TickStats {
+    const stats: TickStats = {
+        totalTicks: ticks.length,
+        totalPitches: 0,
+        leadCount: 0,
+        leadPitches: 0,
+        redpointCount: 0,
+        onsightCount: 0,
+        flashCount: 0,
+        byGrade: {},
+        byGradeLeads: {},
+        byGradeRedpoints: {},
+        byRouteType: {},
+        byMonth: {},
+        pitchesByMonth: {},
+        multipitchCount: 0,
+        singlepitchCount: 0,
+        uniqueDays: 0,
+        highestRedpoint: '',
+        favoriteArea: '',
+    };
+
+    const uniqueDates = new Set<string>();
+    const areaCount: Record<string, number> = {};
+    let highestRedpointValue = -1;
+
+    for (const tick of ticks) {
+        const route = tick.route;
+        if (!route) continue;
+
+        // Count pitches
+        const pitches = route.pitches || 1;
+        stats.totalPitches += pitches;
+
+        // Track unique climbing days
+        if (tick.tickDate) {
+            uniqueDates.add(tick.tickDate);
+        }
+
+        // Lead vs follow stats
+        const isLead = tick.style?.toLowerCase() === 'lead';
+        if (isLead) {
+            stats.leadCount++;
+            stats.leadPitches += pitches;
+        }
+
+        // Lead style stats
+        const leadStyle = tick.leadStyle?.toLowerCase();
+        // isRedpoint includes redpoint/onsight/flash, plus leads with no lead style specified
+        const isRedpoint = leadStyle === 'redpoint' || leadStyle === 'onsight' || leadStyle === 'flash' || (isLead && !leadStyle);
+        if (leadStyle === 'redpoint') stats.redpointCount++;
+        if (leadStyle === 'onsight') stats.onsightCount++;
+        if (leadStyle === 'flash') stats.flashCount++;
+
+        // Grade distribution (all routes)
+        const grade = extractGrade(route.rating);
+        stats.byGrade[grade] = (stats.byGrade[grade] || 0) + 1;
+
+        // Grade distribution (leads only)
+        if (isLead) {
+            stats.byGradeLeads[grade] = (stats.byGradeLeads[grade] || 0) + 1;
+        }
+
+        // Grade distribution (redpoints only - includes onsight and flash)
+        if (isRedpoint) {
+            stats.byGradeRedpoints[grade] = (stats.byGradeRedpoints[grade] || 0) + 1;
+        }
+
+        // Track highest redpoint (includes onsight and flash as they're also clean sends)
+        if (isRedpoint) {
+            const gradeValue = parseGrade(route.rating);
+            if (gradeValue > highestRedpointValue) {
+                highestRedpointValue = gradeValue;
+                stats.highestRedpoint = grade;
+            }
+        }
+
+        // Route type distribution
+        const routeType = route.routeType || 'Unknown';
+        stats.byRouteType[routeType] = (stats.byRouteType[routeType] || 0) + 1;
+
+        // Single vs multipitch
+        if (pitches > 1) {
+            stats.multipitchCount++;
+        } else {
+            stats.singlepitchCount++;
+        }
+
+        // Monthly distribution (climbs and pitches)
+        if (tick.tickDate) {
+            const month = tick.tickDate.substring(0, 7); // YYYY-MM
+            stats.byMonth[month] = (stats.byMonth[month] || 0) + 1;
+            stats.pitchesByMonth[month] = (stats.pitchesByMonth[month] || 0) + pitches;
+        }
+
+        // Area/location tracking (get first part of location)
+        if (route.location) {
+            const area = route.location.split(' > ')[0];
+            areaCount[area] = (areaCount[area] || 0) + 1;
+        }
+    }
+
+    stats.uniqueDays = uniqueDates.size;
+
+    // Find favorite area (most climbed)
+    let maxAreaCount = 0;
+    for (const [area, count] of Object.entries(areaCount)) {
+        if (count > maxAreaCount) {
+            maxAreaCount = count;
+            stats.favoriteArea = area;
+        }
+    }
+
+    return stats;
+}
+
+export interface GoalProgress {
+    goal: ClimbingGoal;
+    current: number;
+    target: number;
+    percent: number;
+    isComplete: boolean;
+}
+
+/**
+ * Compute progress towards a climbing goal
+ */
+export function computeGoalProgress(goal: ClimbingGoal, ticks: ClimbingTick[]): GoalProgress {
+    let current = 0;
+
+    // Filter ticks by person if goal has a person
+    let filteredTicks = ticks;
+    if (goal.person?.documentId) {
+        filteredTicks = ticks.filter(t => t.person?.documentId === goal.person?.documentId);
+    }
+
+    // Filter by year
+    filteredTicks = filteredTicks.filter(t => {
+        if (!t.tickDate) return false;
+        const tickYear = parseInt(t.tickDate.substring(0, 4));
+        return tickYear === goal.year;
+    });
+
+    switch (goal.goalType) {
+        case 'lead_pitches':
+            current = filteredTicks
+                .filter(t => t.style?.toLowerCase() === 'lead')
+                .reduce((sum, t) => sum + (t.route?.pitches || 1), 0);
+            break;
+
+        case 'lead_climbs':
+            current = filteredTicks
+                .filter(t => t.style?.toLowerCase() === 'lead')
+                .length;
+            break;
+
+        case 'redpoints':
+            current = filteredTicks
+                .filter(t => t.leadStyle?.toLowerCase() === 'redpoint')
+                .length;
+            break;
+
+        case 'onsights':
+            current = filteredTicks
+                .filter(t => t.leadStyle?.toLowerCase() === 'onsight')
+                .length;
+            break;
+
+        case 'grade_target':
+            current = filteredTicks
+                .filter(t => {
+                    // Check grade requirement
+                    if (goal.minGrade && !isGradeAtOrAbove(t.route?.rating || '', goal.minGrade)) {
+                        return false;
+                    }
+                    // Check route type requirement
+                    if (goal.routeType && t.route?.routeType?.toLowerCase() !== goal.routeType.toLowerCase()) {
+                        return false;
+                    }
+                    return true;
+                })
+                .length;
+            break;
+    }
+
+    const percent = Math.min(100, Math.round((current / goal.targetCount) * 100));
+
+    return {
+        goal,
+        current,
+        target: goal.targetCount,
+        percent,
+        isComplete: current >= goal.targetCount,
+    };
+}
+
+/**
+ * Get a sorted array of grades for pyramid display
+ * Returns grades sorted from highest to lowest
+ */
+export function getSortedGrades(byGrade: Record<string, number>): Array<{ grade: string; count: number }> {
+    return Object.entries(byGrade)
+        .map(([grade, count]) => ({ grade, count }))
+        .sort((a, b) => parseGrade(b.grade) - parseGrade(a.grade));
+}
+
+export interface ActivityData {
+    label: string;
+    climbs: number;
+    pitches: number;
+}
+
+/**
+ * Get monthly activity data for a specific year
+ */
+export function getMonthlyActivity(byMonth: Record<string, number>, pitchesByMonth: Record<string, number>, year: number): ActivityData[] {
+    const months: ActivityData[] = [];
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    for (let m = 0; m < 12; m++) {
+        const monthKey = `${year}-${String(m + 1).padStart(2, '0')}`;
+        months.push({
+            label: monthNames[m],
+            climbs: byMonth[monthKey] || 0,
+            pitches: pitchesByMonth[monthKey] || 0,
+        });
+    }
+
+    return months;
+}
+
+/**
+ * Get monthly activity data for the last 12 months
+ */
+export function getLast12MonthsActivity(byMonth: Record<string, number>, pitchesByMonth: Record<string, number>): ActivityData[] {
+    const months: ActivityData[] = [];
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const now = new Date();
+
+    for (let i = 11; i >= 0; i--) {
+        const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+        months.push({
+            label: monthNames[date.getMonth()],
+            climbs: byMonth[monthKey] || 0,
+            pitches: pitchesByMonth[monthKey] || 0,
+        });
+    }
+
+    return months;
+}
+
+/**
+ * Get yearly activity data from monthly data
+ */
+export function getYearlyActivity(byMonth: Record<string, number>, pitchesByMonth: Record<string, number>): ActivityData[] {
+    const climbsByYear: Record<string, number> = {};
+    const pitchesByYear: Record<string, number> = {};
+
+    // Aggregate monthly data into years
+    for (const [monthKey, count] of Object.entries(byMonth)) {
+        const year = monthKey.substring(0, 4);
+        climbsByYear[year] = (climbsByYear[year] || 0) + count;
+    }
+
+    for (const [monthKey, count] of Object.entries(pitchesByMonth)) {
+        const year = monthKey.substring(0, 4);
+        pitchesByYear[year] = (pitchesByYear[year] || 0) + count;
+    }
+
+    // Sort years and return as array
+    return Object.keys(climbsByYear)
+        .sort()
+        .map(year => ({
+            label: year,
+            climbs: climbsByYear[year] || 0,
+            pitches: pitchesByYear[year] || 0,
+        }));
+}

--- a/frontend/src/pages/climbing.astro
+++ b/frontend/src/pages/climbing.astro
@@ -1,26 +1,114 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import PhotoGallery from "../components/PhotoGallery.astro";
-import { fetchClimbingTicksPaginated, fetchSiteSettings, type ClimbingTick, type StrapiImage } from "../lib/api";
+import TicklistFilters from "../components/TicklistFilters.astro";
+import StatsCards from "../components/StatsCards.astro";
+import GoalsDashboard from "../components/GoalsDashboard.astro";
+import BarChart from "../components/charts/BarChart.astro";
+import GradePyramid from "../components/charts/GradePyramid.astro";
+import DonutChart from "../components/charts/DonutChart.astro";
+import {
+    fetchAllPeople,
+    fetchAllClimbingTicks,
+    fetchClimbingTicksForPerson,
+    fetchClimbingTicksLast12Months,
+    fetchClimbingTicksLast12MonthsForPerson,
+    fetchClimbingGoals,
+    fetchSiteSettings,
+    type ClimbingTick,
+    type StrapiImage,
+} from "../lib/api";
+import {
+    computeTickStats,
+    computeGoalProgress,
+    getSortedGrades,
+    getMonthlyActivity,
+    getLast12MonthsActivity,
+    getYearlyActivity,
+    type GoalProgress,
+    type ActivityData,
+} from "../lib/tickStats";
 
-const PAGE_SIZE = 50;
+// Get filter params from URL
+const selectedPersonId = Astro.url.searchParams.get('person') || undefined;
+const currentYear = new Date().getFullYear();
+const yearParam = Astro.url.searchParams.get('year');
 
-const [{ ticks, pagination }, siteSettings] = await Promise.all([
-    fetchClimbingTicksPaginated(1, PAGE_SIZE),
+// Fetch data in parallel
+const [people, siteSettings] = await Promise.all([
+    fetchAllPeople(),
     fetchSiteSettings(),
 ]);
 
-const hasMore = pagination.pageCount > 1;
+// Determine the time period to display
+// Default is "Last 12 Months" (no year param)
+let selectedYear: number | undefined = undefined;
+let showAllTime = yearParam === 'all';
+let showLast12Months = !yearParam; // Default when no year param
+
+// Parse year if it's a number
+if (yearParam && yearParam !== 'all') {
+    const parsed = parseInt(yearParam);
+    if (!isNaN(parsed)) {
+        selectedYear = parsed;
+        showLast12Months = false;
+    }
+}
+
+// Fetch ticks based on the selected period
+let ticks: ClimbingTick[];
+if (showAllTime) {
+    // "All time" selected - fetch without date filter
+    ticks = selectedPersonId
+        ? await fetchClimbingTicksForPerson(selectedPersonId)
+        : await fetchAllClimbingTicks();
+} else if (showLast12Months) {
+    // "Last 12 Months" - default view
+    ticks = selectedPersonId
+        ? await fetchClimbingTicksLast12MonthsForPerson(selectedPersonId)
+        : await fetchClimbingTicksLast12Months();
+} else {
+    // Specific year selected
+    ticks = selectedPersonId
+        ? await fetchClimbingTicksForPerson(selectedPersonId, selectedYear)
+        : await fetchAllClimbingTicks(selectedYear);
+}
+
+// Fetch goals if a person is selected
+// For "Last 12 Months" or "All Time", show current year goals
+// For specific years, show that year's goals
+let goals: GoalProgress[] = [];
+let selectedPerson = people.find(p => p.documentId === selectedPersonId);
+if (selectedPersonId) {
+    const goalYear = selectedYear || currentYear;
+    const rawGoals = await fetchClimbingGoals(selectedPersonId, goalYear);
+    // For goals, we need to compute progress against all ticks for the goal's year
+    const ticksForGoals = selectedYear
+        ? ticks
+        : await fetchClimbingTicksForPerson(selectedPersonId, goalYear);
+    goals = rawGoals.map(goal => computeGoalProgress(goal, ticksForGoals));
+}
+
+// Compute stats
+const stats = computeTickStats(ticks);
+
+// Prepare chart data
+const activityData: ActivityData[] = selectedYear
+    ? getMonthlyActivity(stats.byMonth, stats.pitchesByMonth, selectedYear)
+    : showLast12Months
+        ? getLast12MonthsActivity(stats.byMonth, stats.pitchesByMonth)
+        : getYearlyActivity(stats.byMonth, stats.pitchesByMonth);
+const gradeDataAll = getSortedGrades(stats.byGrade);
+const gradeDataLeads = getSortedGrades(stats.byGradeLeads);
+const gradeDataRedpoints = getSortedGrades(stats.byGradeRedpoints);
+const routeTypeData = Object.entries(stats.byRouteType).map(([label, value]) => ({ label, value }));
+
+// Available years for filter (last 5 years + "All time")
+const availableYears = Array.from({ length: 5 }, (_, i) => currentYear - i);
 
 // SEO data
 const siteName = siteSettings?.siteName || "Hill People";
-const description = "Our climbing log - routes we've climbed, organized by date.";
-
-// Helper function to format route type
-function formatRouteType(routeType: string): string {
-    if (!routeType) return "";
-    return routeType;
-}
+const description = "The Ticklist - our climbing log with stats, goals, and route history.";
 
 // Grouped route entry - dedupes multiple climbers on same route/date
 interface GroupedRoute {
@@ -29,6 +117,8 @@ interface GroupedRoute {
     bestStars: number;
     photos: StrapiImage[];
     notes: string[];
+    style?: string;
+    leadStyle?: string;
 }
 
 // Group ticks by date, then by route (deduping multiple climbers)
@@ -58,6 +148,8 @@ function groupTicksByDateAndRoute(tickList: ClimbingTick[]): TicksByDate[] {
                 bestStars: 0,
                 photos: [],
                 notes: [],
+                style: tick.style,
+                leadStyle: tick.leadStyle,
             });
         }
 
@@ -76,7 +168,6 @@ function groupTicksByDateAndRoute(tickList: ClimbingTick[]): TicksByDate[] {
         // Collect photos from all ticks for this route
         if (tick.photos?.length) {
             for (const photo of tick.photos) {
-                // Avoid duplicates by checking ID
                 if (!groupedRoute.photos.some(p => p.id === photo.id)) {
                     groupedRoute.photos.push(photo);
                 }
@@ -102,96 +193,152 @@ function groupTicksByDateAndRoute(tickList: ClimbingTick[]): TicksByDate[] {
 }
 
 const ticksByDate = groupTicksByDateAndRoute(ticks);
-
-// Count unique routes for display
-const uniqueRouteCount = ticksByDate.reduce((sum, day) => sum + day.routes.length, 0);
 ---
 
 <Layout
-    pageTitle="Climbing Log"
+    pageTitle="The Ticklist"
     description={description}
     siteName={siteName}
 >
-    <div class="max-w-4xl mx-auto px-4 py-10">
-        <h1 class="text-4xl font-bold mb-2">Climbing Log</h1>
-        <p class="text-lg mb-8 opacity-80">
-            {uniqueRouteCount} routes climbed
-        </p>
+    <div class="max-w-5xl mx-auto px-4 py-10">
+        <!-- Header -->
+        <header class="text-center mb-8">
+            <h1 class="text-4xl font-bold mb-2">The Ticklist</h1>
+            <p class="text-lg opacity-80">
+                {selectedPerson
+                    ? `${selectedPerson.name}'s ${showAllTime ? 'all-time' : showLast12Months ? 'last 12 months' : selectedYear} routes`
+                    : showAllTime ? 'All-time routes' : showLast12Months ? 'Last 12 months' : `${selectedYear} routes`}
+            </p>
+        </header>
 
-        <div id="ticks-container">
-            {ticksByDate.map(({ date, formattedDate, routes }) => (
-                <div class="mb-8" data-date={date}>
-                    <h2 class="text-xl font-semibold mb-3 sticky top-0 bg-[var(--color-bg)] py-2 border-b border-[var(--color-accent)]">
-                        {formattedDate}
-                    </h2>
-                    <div class="space-y-2">
-                        {routes.map((groupedRoute) => (
-                            <div class="tick-item flex items-start gap-4 p-3 rounded-lg border border-[var(--color-accent)] hover:border-[var(--color-header)] transition">
-                                <div class="flex-1 min-w-0">
-                                    <div class="flex items-baseline gap-2 flex-wrap">
-                                        <a
-                                            href={groupedRoute.route?.mountainProjectUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            class="font-semibold hover:underline text-[var(--color-header)]"
-                                        >
-                                            {groupedRoute.route?.name || "Unknown Route"}
-                                        </a>
-                                        {groupedRoute.route?.rating && (
-                                            <span class="text-sm font-mono">{groupedRoute.route.rating}</span>
-                                        )}
-                                        {groupedRoute.route?.routeType && (
-                                            <span class="text-xs opacity-70">{formatRouteType(groupedRoute.route.routeType)}</span>
-                                        )}
-                                    </div>
-                                    {groupedRoute.route?.location && (
-                                        <p class="text-sm truncate">{groupedRoute.route.location}</p>
-                                    )}
-                                    {groupedRoute.climbers.length > 0 && (
-                                        <p class="text-xs mt-1 opacity-70">
-                                            {groupedRoute.climbers.join(" & ")}
-                                        </p>
-                                    )}
-                                    {groupedRoute.notes.length > 0 && (
-                                        <p class="text-sm mt-2 italic opacity-80">
-                                            {groupedRoute.notes.join(" · ")}
-                                        </p>
-                                    )}
-                                    <PhotoGallery
-                                        photos={groupedRoute.photos}
-                                        galleryId={`${date}-${groupedRoute.route?.documentId || 'unknown'}`}
-                                    />
-                                </div>
-                                {groupedRoute.bestStars > 0 && (
-                                    <div class="flex-shrink-0 text-sm text-[var(--color-header)]" title={`${groupedRoute.bestStars} stars`}>
-                                        {"★".repeat(groupedRoute.bestStars)}{"☆".repeat(4 - groupedRoute.bestStars)}
-                                    </div>
-                                )}
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            ))}
-        </div>
+        <!-- Filters -->
+        <TicklistFilters
+            people={people}
+            selectedPersonId={selectedPersonId}
+            selectedYear={selectedYear}
+            showAllTime={showAllTime}
+            showLast12Months={showLast12Months}
+            availableYears={availableYears}
+        />
 
-        {ticks.length === 0 && (
-            <p class="text-center opacity-60 py-10">No climbing ticks yet.</p>
+        <!-- Goals Dashboard (if person selected and has goals) -->
+        {goals.length > 0 && (
+            <GoalsDashboard goals={goals} personName={selectedPerson?.name} goalYear={selectedYear || currentYear} />
         )}
 
-        {hasMore && (
-            <div class="text-center mt-10">
-                <button
-                    id="load-more-ticks"
-                    type="button"
-                    data-page="2"
-                    data-page-size={PAGE_SIZE}
-                    class="bg-[var(--color-fab-bg)] text-[var(--color-fab-text)] border-2 border-[var(--color-fab-text)] px-6 py-3 rounded-lg font-semibold hover:opacity-90 transition w-full sm:w-auto"
-                >
-                    Load more
-                </button>
+        <!-- Stats Cards -->
+        {stats.totalTicks > 0 && (
+            <StatsCards stats={stats} />
+        )}
+
+        <!-- Charts Section -->
+        {stats.totalTicks > 0 && (
+            <div class="charts-section grid md:grid-cols-2 gap-8 mb-12">
+                <!-- Activity Over Time -->
+                {activityData.length > 0 && (
+                    <div class="chart-card bg-[var(--color-accent)]/5 rounded-xl p-6 flex flex-col">
+                        <BarChart data={activityData} title={showAllTime ? "Yearly Activity" : "Monthly Activity"} height={220} />
+                    </div>
+                )}
+
+                <!-- Route Type Breakdown -->
+                <div class="chart-card bg-[var(--color-accent)]/5 rounded-xl p-6 flex flex-col">
+                    <DonutChart data={routeTypeData} title="Route Types" size={160} />
+                </div>
             </div>
         )}
+
+        <!-- Grade Pyramid (full width) -->
+        {gradeDataAll.length > 0 && (
+            <div class="chart-card bg-[var(--color-accent)]/5 rounded-xl p-6 mb-12">
+                <GradePyramid
+                    allRoutes={gradeDataAll}
+                    leads={gradeDataLeads}
+                    redpoints={gradeDataRedpoints}
+                    title="Grade Pyramid"
+                />
+            </div>
+        )}
+
+        <!-- Tick List -->
+        <section>
+            <h2 class="text-2xl font-bold mb-6">
+                {showAllTime ? 'All' : showLast12Months ? 'Recent' : selectedYear} Sends
+                <span class="text-lg font-normal opacity-70 ml-2">({stats.totalTicks} routes)</span>
+            </h2>
+
+            <div id="ticks-container">
+                {ticksByDate.map(({ date, formattedDate, routes }) => (
+                    <div class="mb-8" data-date={date}>
+                        <h3 class="text-lg font-semibold mb-3 sticky top-0 bg-[var(--color-bg)] py-2 border-b border-[var(--color-accent)]/30">
+                            {formattedDate}
+                        </h3>
+                        <div class="space-y-2">
+                            {routes.map((groupedRoute) => (
+                                <div class="tick-item flex items-start gap-4 p-3 rounded-lg border border-[var(--color-accent)]/30 hover:border-[var(--color-header)] transition">
+                                    <div class="flex-1 min-w-0">
+                                        <div class="flex items-baseline gap-2 flex-wrap">
+                                            <a
+                                                href={groupedRoute.route?.mountainProjectUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                class="font-semibold hover:underline text-[var(--color-header)]"
+                                            >
+                                                {groupedRoute.route?.name || "Unknown Route"}
+                                            </a>
+                                            {groupedRoute.route?.rating && (
+                                                <span class="text-sm font-mono">{groupedRoute.route.rating}</span>
+                                            )}
+                                            {groupedRoute.route?.routeType && (
+                                                <span class="text-xs opacity-70">{groupedRoute.route.routeType}</span>
+                                            )}
+                                            {groupedRoute.style && (
+                                                <span class="text-xs px-2 py-0.5 rounded bg-[var(--color-accent)]/20">
+                                                    {groupedRoute.style}
+                                                    {groupedRoute.leadStyle && ` · ${groupedRoute.leadStyle}`}
+                                                </span>
+                                            )}
+                                        </div>
+                                        {groupedRoute.route?.location && (
+                                            <p class="text-sm truncate opacity-80">{groupedRoute.route.location}</p>
+                                        )}
+                                        {groupedRoute.climbers.length > 0 && (
+                                            <p class="text-xs mt-1 opacity-70">
+                                                {groupedRoute.climbers.join(" & ")}
+                                            </p>
+                                        )}
+                                        {groupedRoute.notes.length > 0 && (
+                                            <p class="text-sm mt-2 italic opacity-80">
+                                                {groupedRoute.notes.join(" · ")}
+                                            </p>
+                                        )}
+                                        <PhotoGallery
+                                            photos={groupedRoute.photos}
+                                            galleryId={`${date}-${groupedRoute.route?.documentId || 'unknown'}`}
+                                        />
+                                    </div>
+                                    {groupedRoute.bestStars > 0 && (
+                                        <div class="flex-shrink-0 text-sm text-[var(--color-header)]" title={`${groupedRoute.bestStars} stars`}>
+                                            {"★".repeat(groupedRoute.bestStars)}{"☆".repeat(4 - groupedRoute.bestStars)}
+                                        </div>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+
+            {ticks.length === 0 && (
+                <div class="text-center py-16 opacity-60">
+                    <p class="text-lg mb-2">No climbs logged{showAllTime ? '' : showLast12Months ? ' in the last 12 months' : ` for ${selectedYear}`}</p>
+                    <p class="text-sm">
+                        {selectedPerson
+                            ? `${selectedPerson.name} hasn't logged any climbs yet.`
+                            : 'Try selecting a different period or person.'}
+                    </p>
+                </div>
+            )}
+        </section>
     </div>
 </Layout>
-
-<script src="../scripts/load-more-ticks.ts"></script>


### PR DESCRIPTION
## Summary
- Transforms the climbing log into an interactive dashboard with person/time filters
- Adds stats cards, bar chart (monthly/yearly activity), donut chart (route types), and grade pyramid
- Implements goals dashboard with progress bars for annual climbing targets
- Creates new `climbing-goal` content type in Strapi backend

## Test plan
- [x] Visit `/climbing` and verify filters work (person selector, year selector)
- [x] Check stats cards show accurate counts
- [x] Verify bar chart toggles between pitches/climbs
- [x] Test grade pyramid mode switching (Hardo/Normal/Top Rope Tough Guy)
- [x] Select a person with goals and verify progress bars render correctly
- [x] Test responsive layout on mobile

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)