### PR TITLE
Fix subscribe endpoint leaking Strapi confirmation token

### DIFF
--- a/frontend/src/scripts/newsletter-signup.ts
+++ b/frontend/src/scripts/newsletter-signup.ts
@@ -76,14 +76,7 @@ export function initNewsletterSignup() {
         submitButton.textContent = 'Subscribed!';
       } else {
         const errorData = await res.json().catch(() => ({}));
-        const errorMessage = errorData?.error?.message || 'Something went wrong. Please try again.';
-
-        // Handle duplicate email
-        if (errorMessage.includes('unique') || errorMessage.includes('already')) {
-          message.textContent = 'This email is already subscribed.';
-        } else {
-          message.textContent = errorMessage;
-        }
+        message.textContent = errorData?.error?.message || 'Something went wrong. Please try again.';
         message.classList.remove('hidden', 'text-green-300');
         message.classList.add('text-red-400');
         submitButton.disabled = false;


### PR DESCRIPTION
## Summary
- Don't return Strapi response data on success (it contains the confirmation token)
- Return only `{ success: true }` on successful subscription
- Sanitize error messages server-side (handle "already subscribed" case)
- Simplify client error handling since server now formats messages

## Test plan
- [x] Test newsletter signup with new email
- [x] Test newsletter signup with already-subscribed email
- [x] Verify Network tab shows no confirmation token in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)