### PR TITLE
Fix React 19 MessageChannel error on Cloudflare Workers

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -21,6 +21,14 @@ export default defineConfig({
 
   vite: {
     plugins: [tailwindcss()],
+    resolve: {
+      // Use react-dom/server.edge instead of react-dom/server.browser for React 19.
+      // Without this, MessageChannel from node:worker_threads needs to be polyfilled.
+      // See: https://github.com/withastro/astro/issues/12824
+      alias: import.meta.env.PROD ? {
+        'react-dom/server': 'react-dom/server.edge',
+      } : {},
+    },
   },
 
   adapter: cloudflare(),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,8 @@
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/react": "^4.4.2",
         "@tailwindcss/vite": "^4.1.3",
+        "@types/react": "^19.2.10",
+        "@types/react-dom": "^19.2.3",
         "astro": "^5.17.1",
         "framer-motion": "^12.31.0",
         "react": "^19.2.4",
@@ -2268,7 +2270,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2278,7 +2279,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2972,8 +2972,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/react": "^4.4.2",
     "@tailwindcss/vite": "^4.1.3",
+    "@types/react": "^19.2.10",
+    "@types/react-dom": "^19.2.3",
     "astro": "^5.17.1",
     "framer-motion": "^12.31.0",
     "react": "^19.2.4",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,14 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "include": [
+    ".astro/types.d.ts",
+    "**/*"
+  ],
+  "exclude": [
+    "dist"
+  ],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION
## Summary
- Add Vite alias to use `react-dom/server.edge` instead of `react-dom/server.browser` in production builds
- The browser version uses `MessageChannel` which is not available in Cloudflare Workers runtime
- Add React types and proper JSX configuration to tsconfig.json

## Test plan
- [x] Verify Cloudflare deployment succeeds
- [x] Verify climbing page charts render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)