### PR TITLE
Fix canonical URLs to use HTTPS without query params

### DIFF
--- a/frontend/src/components/SEO.astro
+++ b/frontend/src/components/SEO.astro
@@ -24,7 +24,9 @@ const {
 } = Astro.props;
 
 const fullTitle = title === 'Home' ? siteName : `${title} - ${siteName}`;
-const url = canonicalUrl || Astro.url.href;
+// Build canonical URL from site config + pathname (no query params, always HTTPS)
+const siteUrl = import.meta.env.SITE || 'https://hillpeople.net';
+const url = canonicalUrl || `${siteUrl}${Astro.url.pathname}`;
 ---
 
 <!-- Primary Meta Tags -->


### PR DESCRIPTION
## Summary

Fix "Duplicate without user-selected canonical" errors in Google Search Console.

### Problem
The SEO component was using `Astro.url.href` for canonical URLs, which could include:
- Query parameters (e.g., `?status=draft`)
- Incorrect protocol (HTTP instead of HTTPS) depending on how the request arrived

### Solution
Construct canonical URLs from:
- `import.meta.env.SITE` (always `https://hillpeople.net`)
- `Astro.url.pathname` (path only, no query params)

This ensures all canonical tags point to clean HTTPS URLs regardless of how the page was accessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)