### PR TITLE
Add custom 404 page

### DIFF
--- a/frontend/src/pages/404.astro
+++ b/frontend/src/pages/404.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { fetchSiteSettings } from "../lib/api";
+
+const siteSettings = await fetchSiteSettings();
+const siteName = siteSettings?.siteName || "Hill People";
+---
+
+<Layout
+    pageTitle="Page Not Found"
+    description="The page you're looking for doesn't exist."
+    siteName={siteName}
+    noindex={true}
+>
+    <div class="max-w-3xl mx-auto px-4 py-20 text-center">
+        <h1 class="text-6xl font-bold mb-4">404</h1>
+        <p class="text-xl text-gray-600 mb-8">
+            The page you're looking for doesn't exist or has been moved.
+        </p>
+        <a
+            href="/"
+            class="inline-block px-6 py-3 bg-[var(--color-fab-bg)] text-[var(--color-fab-text)] rounded-lg hover:opacity-90 transition-opacity"
+        >
+            Go back home
+        </a>
+    </div>
+</Layout>


### PR DESCRIPTION
## Summary

Add a custom 404 page that matches the site's design.

- Shows "404" heading with friendly message
- Link to return to homepage
- Uses site's color scheme and layout
- Marked as `noindex` for SEO

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)