### PR TITLE
Remove duplicate BlogPosting structured data

### DIFF
--- a/frontend/src/pages/blog/[slug].astro
+++ b/frontend/src/pages/blog/[slug].astro
@@ -87,7 +87,7 @@ const structuredData = {
 >
   <StructuredData data={structuredData} />
 
-  <article itemscope itemtype="https://schema.org/BlogPosting">
+  <article>
     {coverImage && (
       <ResponsiveHeroImage
         image={coverImage}


### PR DESCRIPTION
## Summary

- Remove duplicate BlogPosting structured data from blog post pages

## Problem

The blog post page had both:
1. **JSON-LD** structured data (via `<StructuredData>` component)
2. **Microdata** structured data (`itemscope itemtype="https://schema.org/BlogPosting"` on `<article>`)

This caused schema.org validators to detect two BlogPosting objects on each page.

## Solution

Removed the microdata attributes from the `<article>` tag, keeping only JSON-LD which is the [Google-recommended approach](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data#structured-data-format).

🤖 Generated with [Claude Code](https://claude.ai/code)