### PR TITLE
Fix canonical URL trailing slash mismatch

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -8,7 +8,8 @@ import cloudflare from '@astrojs/cloudflare';
 // https://astro.build/config
 export default defineConfig({
   output: 'server',
-  site:'https://hillpeople.net',
+  site: 'https://hillpeople.net',
+  trailingSlash: 'never',
 
   env: {
     schema: {

--- a/frontend/src/components/SEO.astro
+++ b/frontend/src/components/SEO.astro
@@ -25,8 +25,10 @@ const {
 
 const fullTitle = title === 'Home' ? siteName : `${title} - ${siteName}`;
 // Build canonical URL from site config + pathname (no query params, always HTTPS)
+// Normalize to remove trailing slashes (except for root "/") to match Google's preference
 const siteUrl = import.meta.env.SITE || 'https://hillpeople.net';
-const url = canonicalUrl || `${siteUrl}${Astro.url.pathname}`;
+const pathname = Astro.url.pathname.replace(/\/+$/, '') || '/';
+const url = canonicalUrl || `${siteUrl}${pathname}`;
 ---
 
 <!-- Primary Meta Tags -->


### PR DESCRIPTION
## Summary
- Set `trailingSlash: 'never'` in Astro config for consistent URL handling
- Normalize canonical URLs in SEO component to remove trailing slashes (except for root `/`)

## Problem
Google Search Console was rejecting pages with **"Duplicate, Google chose different canonical than user"** because:
- Site declared canonical: `https://hillpeople.net/blog/ski-season-actually-starts-in-april/` (with trailing slash)
- Google selected: `https://hillpeople.net/blog/ski-season-actually-starts-in-april` (without trailing slash)

## Test plan
- [ ] Verify canonical URLs no longer have trailing slashes in page source
- [ ] Request re-indexing in Google Search Console after deployment
- [ ] Confirm sitemap URLs remain without trailing slashes

🤖 Generated with [Claude Code](https://claude.ai/code)