### PR TITLE
Fix newsletter rate limiting for Resend API

### DIFF
--- a/backend/src/plugins/newsletter/server/src/services/newsletter-service.ts
+++ b/backend/src/plugins/newsletter/server/src/services/newsletter-service.ts
@@ -269,14 +269,17 @@ const service = ({ strapi }: { strapi: Core.Strapi }) => ({
       } as any,
     });
 
-    // Send to each subscriber
+    // Send to each subscriber (with delay to respect Resend's 2 req/s rate limit)
     const emailService = strapi.plugin('newsletter').service('email-service');
     const templateService = strapi.plugin('newsletter').service('template-service');
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
     let successCount = 0;
     let failureCount = 0;
     const errors: Array<{ email: string; error: string }> = [];
 
-    for (const subscriber of subscribers) {
+    for (let i = 0; i < subscribers.length; i++) {
+      if (i > 0) await delay(600);
+      const subscriber = subscribers[i];
       try {
         const unsubscribeUrl = subscriber.unsubscribeToken
           ? `${frontendUrl}/newsletter/unsubscribe/${subscriber.unsubscribeToken}`


### PR DESCRIPTION
Adds a 600ms delay between email sends to stay within Resend's 2 req/s rate limit.

## Problem

The cron send loop fires emails back-to-back. After the first 2 succeed, all remaining sends get a 429 Too Many Requests from Resend. On the 2026-02-06 run, 4 of 6 subscribers did not receive the newsletter.

## Fix

Simple `await delay(600)` between iterations. At 600ms per send, a 100-subscriber list takes ~1 minute — acceptable for a background cron job.

Closes #143