### PR TITLE
Resize images client-side to fix upload crashes

### DIFF
--- a/backend/src/admin/plugins/FolderAwareUploadAdapter.ts
+++ b/backend/src/admin/plugins/FolderAwareUploadAdapter.ts
@@ -11,6 +11,7 @@
 import { Plugin, FileRepository } from 'ckeditor5';
 import { getArticleContext, getFolderPath } from '../utils/articleContext';
 import { ensureFolderPath } from '../utils/folderManager';
+import { resizeImageIfNeeded } from '../utils/resizeImage';
 
 interface UploadConfig {
   uploadUrl: string;
@@ -63,18 +64,20 @@ class FolderAwareAdapter {
   }
 
   /**
-   * Starts the upload process
+   * Starts the upload process — resizes large images client-side first
    */
   upload(): Promise<{ alt?: string; urls?: Record<string | number, string> }> {
-    return this.loader.file.then((file) => {
-      return this.getFolderId().then((folderId) => {
-        return new Promise<{ alt?: string; urls?: Record<string | number, string> }>((resolve, reject) => {
-          this.initRequest();
-          this.initListeners(resolve, reject, file);
-          this.sendRequest(file, folderId);
+    return this.loader.file
+      .then((file) => resizeImageIfNeeded(file))
+      .then((file) => {
+        return this.getFolderId().then((folderId) => {
+          return new Promise<{ alt?: string; urls?: Record<string | number, string> }>((resolve, reject) => {
+            this.initRequest();
+            this.initListeners(resolve, reject, file);
+            this.sendRequest(file, folderId);
+          });
         });
       });
-    });
   }
 
   /**

--- a/backend/src/admin/utils/resizeImage.ts
+++ b/backend/src/admin/utils/resizeImage.ts
@@ -1,0 +1,83 @@
+/**
+ * Resizes an image file in the browser before upload using Canvas API.
+ *
+ * Only resizes if the image exceeds MAX_DIMENSION on either side.
+ * Non-image files and small images are returned unchanged.
+ */
+
+const MAX_DIMENSION = 2400;
+const JPEG_QUALITY = 0.85;
+
+const RESIZABLE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+/**
+ * Loads a File as an HTMLImageElement.
+ */
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error(`Failed to load image: ${file.name}`));
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Resizes an image file if it exceeds MAX_DIMENSION on either axis.
+ * Returns the original file if no resize is needed or the type isn't supported.
+ */
+export async function resizeImageIfNeeded(file: File): Promise<File> {
+  if (!RESIZABLE_TYPES.has(file.type)) {
+    return file;
+  }
+
+  const img = await loadImage(file);
+  const { naturalWidth: w, naturalHeight: h } = img;
+
+  if (w <= MAX_DIMENSION && h <= MAX_DIMENSION) {
+    return file;
+  }
+
+  // Calculate scaled dimensions preserving aspect ratio
+  const scale = MAX_DIMENSION / Math.max(w, h);
+  const newW = Math.round(w * scale);
+  const newH = Math.round(h * scale);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = newW;
+  canvas.height = newH;
+
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0, newW, newH);
+
+  // Output as JPEG for photos (smaller than PNG), keep original type for others
+  const outputType = file.type === 'image/png' ? 'image/png' : 'image/jpeg';
+  const quality = outputType === 'image/jpeg' ? JPEG_QUALITY : undefined;
+
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Canvas toBlob failed'))),
+      outputType,
+      quality
+    );
+  });
+
+  // Preserve original filename but adjust extension if type changed
+  let name = file.name;
+  if (file.type !== outputType) {
+    name = name.replace(/\.[^.]+$/, '.jpg');
+  }
+
+  return new File([blob], name, { type: outputType, lastModified: file.lastModified });
+}

--- a/frontend/src/pages/img/[...path].ts
+++ b/frontend/src/pages/img/[...path].ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { STRAPI_API_URL } from 'astro:env/server';
 
 const STRAPI_MEDIA_HOST = 'competent-victory-0bdd9770d0.media.strapiapp.com';
 
@@ -12,7 +13,11 @@ export const GET: APIRoute = async ({ params }) => {
     return new Response('Not found', { status: 404 });
   }
 
-  const strapiUrl = `https://${STRAPI_MEDIA_HOST}/${path}`;
+  // Local uploads (e.g. /img/uploads/foo.jpg) go to Strapi API URL,
+  // everything else goes to the Strapi Cloud media CDN
+  const strapiUrl = path.startsWith('uploads/')
+    ? `${STRAPI_API_URL}/${path}`
+    : `https://${STRAPI_MEDIA_HOST}/${path}`;
 
   try {
     const response = await fetch(strapiUrl);


### PR DESCRIPTION
## Summary
- Adds browser-side image resizing before CKEditor drag-and-drop upload (max 2400px, JPEG 85%)
- Fixes the `/img` proxy to work with local Strapi uploads during development

Builds on #161 (`sharp.concurrency(1)`) which is already merged. Together these two changes fix large image uploads crashing Strapi Cloud — the client-side resize prevents oversized files from reaching the server, and the server-side concurrency limit provides defense in depth.

## Context
Uploading a raw phone photo (~8MB, 6000x6000) to Strapi Cloud causes a 503 crash (`upstream_reset_before_response_started{connection_termination}`) because Sharp's responsive format generation exhausts the instance's memory. Resizing to 2400px in the browser before upload reduces the file to ~200-500KB, well within Strapi Cloud's limits.

## Changes
- **`backend/src/admin/utils/resizeImage.ts`** — new utility: resizes JPEG/PNG/WebP images >2400px using Canvas API
- **`backend/src/admin/plugins/FolderAwareUploadAdapter.ts`** — calls `resizeImageIfNeeded()` before upload
- **`frontend/src/pages/img/[...path].ts`** — routes `/img/uploads/*` to `STRAPI_API_URL` instead of hardcoded cloud CDN host

## Test plan
- [ ] Upload a large photo (>2400px) via CKEditor drag-and-drop on Strapi Cloud — verify no crash, image uploads successfully
- [ ] Verify uploaded image displays correctly on the frontend
- [ ] Upload a small image (<2400px) — verify it passes through unchanged
- [ ] Upload a non-image file — verify it passes through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)