### PR TITLE
Fix plugin admin TypeScript build for Strapi Cloud deployment

### DIFF
--- a/backend/src/plugins/mp-sync-helper/admin/src/pages/HomePage.tsx
+++ b/backend/src/plugins/mp-sync-helper/admin/src/pages/HomePage.tsx
@@ -42,6 +42,10 @@ interface SyncResponse {
   results: Array<{ person: string; result: SyncResult }>;
 }
 
+interface PeopleListResponse {
+  results: Person[];
+}
+
 const HomePage = () => {
   const [people, setPeople] = useState<Person[]>([]);
   const [loading, setLoading] = useState(true);
@@ -55,7 +59,8 @@ const HomePage = () => {
     try {
       setLoading(true);
       const { data } = await get('/content-manager/collection-types/api::person.person');
-      setPeople(data.results || []);
+      const peopleData = data as PeopleListResponse;
+      setPeople(peopleData.results || []);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch people');
     } finally {

--- a/backend/src/plugins/newsletter/admin/src/components/HistoryTab.tsx
+++ b/backend/src/plugins/newsletter/admin/src/components/HistoryTab.tsx
@@ -43,6 +43,11 @@ const TRIGGER_COLORS: Record<string, { bg: string; text: string }> = {
   test: { bg: 'warning100', text: 'warning700' },
 };
 
+interface HistoryResponse {
+  results: SendRecord[];
+  pagination?: { total: number };
+}
+
 const HistoryTab = () => {
   const [sends, setSends] = useState<SendRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -57,8 +62,9 @@ const HistoryTab = () => {
     try {
       setLoading(true);
       const { data } = await get(`/newsletter/history?page=${p}&pageSize=${pageSize}`);
-      setSends(data.results || []);
-      setTotal(data.pagination?.total || 0);
+      const historyData = data as HistoryResponse;
+      setSends(historyData.results || []);
+      setTotal(historyData.pagination?.total || 0);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch history');
     } finally {

--- a/backend/src/plugins/newsletter/admin/src/components/SendTab.tsx
+++ b/backend/src/plugins/newsletter/admin/src/components/SendTab.tsx
@@ -33,6 +33,14 @@ interface Stats {
   lastSend: any;
 }
 
+interface PostsResponse {
+  results: Post[];
+}
+
+interface PreviewResponse {
+  html: string;
+}
+
 const SendTab = () => {
   const [posts, setPosts] = useState<Post[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
@@ -56,8 +64,8 @@ const SendTab = () => {
         get('/newsletter/eligible-posts'),
         get('/newsletter/stats'),
       ]);
-      setPosts(postsRes.data.results || []);
-      setStats(statsRes.data);
+      setPosts((postsRes.data as PostsResponse).results || []);
+      setStats(statsRes.data as Stats);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch data');
     } finally {
@@ -121,7 +129,8 @@ const SendTab = () => {
       setPreviewLoading(true);
       setError(null);
       const { data } = await get('/newsletter/preview');
-      setPreviewHtml(data.html || '');
+      const previewData = data as PreviewResponse;
+      setPreviewHtml(previewData.html || '');
       setShowPreview(true);
     } catch (err: any) {
       setError(err.response?.data?.error?.message || err.message || 'Failed to load preview');

--- a/backend/src/plugins/newsletter/admin/src/components/SettingsTab.tsx
+++ b/backend/src/plugins/newsletter/admin/src/components/SettingsTab.tsx
@@ -70,8 +70,9 @@ const SettingsTab = () => {
     try {
       setLoading(true);
       const { data } = await get('/newsletter/settings');
-      if (data && Object.keys(data).length > 0) {
-        setSettings({ ...DEFAULTS, ...data });
+      const settingsData = data as Partial<Settings>;
+      if (settingsData && Object.keys(settingsData).length > 0) {
+        setSettings({ ...DEFAULTS, ...settingsData });
       }
     } catch (err: any) {
       setError(err.message || 'Failed to fetch settings');


### PR DESCRIPTION
## Summary
- Fix `TS18046: 'data' is of type 'unknown'` errors blocking Strapi Cloud deployment after the Strapi 5.51 upgrade
- Add response type interfaces and assertions in `mp-sync-helper` and `newsletter` plugin admin components where `useFetchClient()` returns untyped data

## Test plan
- [x] `cd backend/src/plugins/mp-sync-helper && npm run build`
- [x] `cd backend/src/plugins/newsletter && npm run build`
- [x] `cd backend && npm run build`
- [ ] Merge and verify Strapi Cloud deployment succeeds


Made with [Cursor](https://cursor.com)